### PR TITLE
Convert to lowercase on unix

### DIFF
--- a/file-formats/archives/wow-mpq/src/path.rs
+++ b/file-formats/archives/wow-mpq/src/path.rs
@@ -67,7 +67,7 @@ pub fn normalize_mpq_path(path: &str) -> String {
 pub fn mpq_path_to_system(path: &str) -> String {
     #[cfg(unix)]
     {
-        path.replace('\\', "/")
+        path.replace('\\', "/").to_lowercase()
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
## Summary
Just convert file names to lowercase on unix