### PR TITLE
m2: Remove transparency animations

### DIFF
--- a/file-formats/graphics/wow-m2/src/header.rs
+++ b/file-formats/graphics/wow-m2/src/header.rs
@@ -132,8 +132,6 @@ pub struct M2Header {
     pub textures: M2Array<u32>,
     /// Transparency lookups
     pub transparency_lookup: M2Array<u16>,
-    /// Transparency animations
-    pub transparency_animations: M2Array<u32>,
     /// Texture flipbooks - only present in BC and earlier
     pub texture_flipbooks: Option<M2Array<u32>>,
     /// Texture animations
@@ -267,7 +265,6 @@ impl M2Header {
 
         let textures = M2Array::parse(reader)?;
         let transparency_lookup = M2Array::parse(reader)?;
-        let transparency_animations = M2Array::parse(reader)?;
 
         // Texture flipbooks only exist in BC and earlier
         let texture_flipbooks = if version <= 263 {
@@ -375,7 +372,6 @@ impl M2Header {
             color_animations,
             textures,
             transparency_lookup,
-            transparency_animations,
             texture_flipbooks,
             texture_animations,
             color_replacements,
@@ -448,7 +444,6 @@ impl M2Header {
 
         self.textures.write(writer)?;
         self.transparency_lookup.write(writer)?;
-        self.transparency_animations.write(writer)?;
 
         // Texture flipbooks only exist in BC and earlier
         if self.version <= 263 {
@@ -572,7 +567,6 @@ impl M2Header {
             color_animations: M2Array::new(0, 0),
             textures: M2Array::new(0, 0),
             transparency_lookup: M2Array::new(0, 0),
-            transparency_animations: M2Array::new(0, 0),
             texture_flipbooks,
             texture_animations: M2Array::new(0, 0),
             color_replacements: M2Array::new(0, 0),

--- a/file-formats/graphics/wow-m2/src/model.rs
+++ b/file-formats/graphics/wow-m2/src/model.rs
@@ -225,7 +225,6 @@ impl Default for M2Model {
                 color_animations: M2Array::default(),
                 textures: M2Array::default(),
                 transparency_lookup: M2Array::default(),
-                transparency_animations: M2Array::default(),
                 texture_flipbooks: None,
                 texture_animations: M2Array::default(),
                 color_replacements: M2Array::default(),
@@ -951,7 +950,6 @@ impl M2Model {
 
         let textures = M2Array::parse(chunk_inner)?;
         let transparency_lookup = M2Array::parse(chunk_inner)?;
-        let transparency_animations = M2Array::parse(chunk_inner)?;
 
         // Texture flipbooks only exist in BC and earlier
         let texture_flipbooks = if version <= 263 {
@@ -1056,7 +1054,6 @@ impl M2Model {
             color_animations,
             textures,
             transparency_lookup,
-            transparency_animations,
             texture_flipbooks,
             texture_animations,
             color_replacements,
@@ -1236,20 +1233,6 @@ impl M2Model {
         // Parse raw data for other sections
         // These are sections we won't fully parse yet but want to preserve
         let mut raw_data = M2RawData::default();
-
-        // Read transparency animations data
-        if header.transparency_animations.count > 0 {
-            reader.seek(SeekFrom::Start(
-                header.transparency_animations.offset as u64,
-            ))?;
-            let mut transparency = vec![
-                0u8;
-                header.transparency_animations.count as usize
-                    * std::mem::size_of::<u32>()
-            ];
-            reader.read_exact(&mut transparency)?;
-            raw_data.transparency = transparency;
-        }
 
         // Read transparency lookup table
         raw_data.transparency_lookup_table =

--- a/warcraft-rs/src/commands/m2.rs
+++ b/warcraft-rs/src/commands/m2.rs
@@ -222,10 +222,6 @@ fn handle_info(path: PathBuf, detailed: bool) -> Result<()> {
         println!("Global Sequences: {}", model.header.global_sequences.count);
         println!("Color Animations: {}", model.header.color_animations.count);
         println!(
-            "Transparency Animations: {}",
-            model.header.transparency_animations.count
-        );
-        println!(
             "Texture Animations: {}",
             model.header.texture_animations.count
         );
@@ -629,10 +625,6 @@ fn handle_tree(path: PathBuf, max_depth: usize, show_size: bool, show_refs: bool
         .with_metadata(
             "color_animations",
             &model.header.color_animations.count.to_string(),
-        )
-        .with_metadata(
-            "transparency_animations",
-            &model.header.transparency_animations.count.to_string(),
         );
 
     if show_size {


### PR DESCRIPTION
I'm not sure about this field, but removing it seems to fix subsequent arrays.