### PR TITLE
mpq: Store File instead of BufReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ use wow_mpq::Archive;
 use wow_blp::parser::load_blp;
 
 // Read files from MPQ archives
-let mut archive = Archive::open("patch.mpq")?;
+let archive = Archive::open("patch.mpq")?;
 let file_data = archive.read_file("Interface\\Icons\\spell.blp")?;
 
 // List files in archive (from listfile)

--- a/docs/formats/archives/mpq.md
+++ b/docs/formats/archives/mpq.md
@@ -634,7 +634,7 @@ use std::path::Path;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ✅ Open an existing MPQ archive
-    let mut archive = Archive::open(Path::new("Data/patch.mpq"))?;
+    let archive = Archive::open(Path::new("Data/patch.mpq"))?;
 
     // ✅ Search for a file
     if let Some(file_info) = archive.find_file("Interface\\Glues\\Models\\UI_Human\\UI_Human.m2")? {

--- a/docs/formats/graphics/blp.md
+++ b/docs/formats/graphics/blp.md
@@ -497,7 +497,7 @@ use wow_blp::{parser::parse_blp, convert::blp_to_image};
 use std::path::Path;
 
 fn extract_spell_icons() -> Result<(), Box<dyn std::error::Error>> {
-    let mut archive = Archive::open("Interface.mpq")?;
+    let archive = Archive::open("Interface.mpq")?;
 
     for file in archive.list_files() {
         if file.starts_with("Interface\\Icons\\") && file.ends_with(".blp") {

--- a/docs/getting-started/basic-usage.md
+++ b/docs/getting-started/basic-usage.md
@@ -66,7 +66,7 @@ fn handle_mpq_error(e: MpqError) {
 use wow_mpq::Archive;
 
 // Open an MPQ archive
-let mut archive = Archive::open("Data/patch.mpq")?;
+let archive = Archive::open("Data/patch.mpq")?;
 
 // Read file data (both path styles work - auto-converted)
 let data = archive.read_file("Interface/FrameXML/UIParent.lua")?;
@@ -104,7 +104,7 @@ use wow_mpq::{Archive, path::mpq_path_to_system};
 use std::path::Path;
 use std::fs;
 
-let mut archive = Archive::open("Data/art.mpq")?;
+let archive = Archive::open("Data/art.mpq")?;
 
 // Extract all files (use list_all() to include files not in listfile)
 if let Ok(entries) = archive.list_all() {
@@ -387,7 +387,7 @@ let texture_ref = Arc::clone(&texture);
 // For MPQ archives, read files on demand
 use wow_mpq::Archive;
 
-let mut archive = Archive::open("huge.mpq")?;
+let archive = Archive::open("huge.mpq")?;
 
 // Read file when needed
 let data = archive.read_file("large_file.dat")?;

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -43,7 +43,7 @@ use wow_mpq::Archive;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Open an MPQ archive
-    let mut archive = Archive::open("path/to/file.mpq")?;
+    let archive = Archive::open("path/to/file.mpq")?;
 
     // List files in the archive (requires listfile)
     if let Ok(entries) = archive.list() {

--- a/docs/guides/dbc-extraction.md
+++ b/docs/guides/dbc-extraction.md
@@ -49,7 +49,7 @@ use std::fs;
 use std::io::Write;
 
 fn extract_dbc_files(mpq_path: &str, output_dir: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
-    let mut archive = Archive::open(mpq_path)?;
+    let archive = Archive::open(mpq_path)?;
     let mut extracted_files = Vec::new();
 
     // Create output directory

--- a/ffi/storm-ffi/tests/test_archive_modification.rs
+++ b/ffi/storm-ffi/tests/test_archive_modification.rs
@@ -47,7 +47,7 @@ fn test_create_archive_and_add_files() {
     // Close and reopen to verify
     drop(archive);
 
-    let mut archive = Archive::open(archive_path).unwrap();
+    let archive = Archive::open(archive_path).unwrap();
 
     // Verify first file exists
     assert!(archive.find_file("test_file.txt").unwrap().is_some());
@@ -229,7 +229,7 @@ fn test_file_enumeration() {
     builder.build(archive_path).unwrap();
 
     // Test file listing
-    let mut archive = Archive::open(archive_path).unwrap();
+    let archive = Archive::open(archive_path).unwrap();
     let file_list = archive.list().unwrap();
 
     // Account for the automatically generated listfile

--- a/file-formats/archives/wow-mpq/README.md
+++ b/file-formats/archives/wow-mpq/README.md
@@ -69,7 +69,7 @@ cargo add wow-mpq
 use wow_mpq::{Archive, ArchiveBuilder, MutableArchive, AddFileOptions};
 
 // Read an existing archive
-let mut archive = Archive::open("Data/common.MPQ")?;
+let archive = Archive::open("Data/common.MPQ")?;
 
 // List all files
 for entry in archive.list()? {

--- a/file-formats/archives/wow-mpq/benches/archive_extraction.rs
+++ b/file-formats/archives/wow-mpq/benches/archive_extraction.rs
@@ -89,7 +89,7 @@ fn bench_single_file_extraction(c: &mut Criterion) {
             &archive_path,
             |b, path| {
                 b.iter(|| {
-                    let mut archive = Archive::open(black_box(path)).unwrap();
+                    let archive = Archive::open(black_box(path)).unwrap();
                     let extracted = archive.read_file("test_file.dat").unwrap();
                     black_box(extracted);
                 });
@@ -130,7 +130,7 @@ fn bench_compressed_extraction(c: &mut Criterion) {
             &archive_path,
             |b, path| {
                 b.iter(|| {
-                    let mut archive = Archive::open(black_box(path)).unwrap();
+                    let archive = Archive::open(black_box(path)).unwrap();
                     let extracted = archive.read_file("test.dat").unwrap();
                     black_box(extracted);
                 });
@@ -176,7 +176,7 @@ fn bench_file_listing(c: &mut Criterion) {
             &archive_path,
             |b, path| {
                 b.iter(|| {
-                    let mut archive = Archive::open(black_box(path)).unwrap();
+                    let archive = Archive::open(black_box(path)).unwrap();
                     let files = archive.list().unwrap();
                     black_box(files);
                 });
@@ -235,7 +235,7 @@ fn bench_random_access(c: &mut Criterion) {
         &(&archive_path, &sequential),
         |b, (path, filenames)| {
             b.iter(|| {
-                let mut archive = Archive::open(black_box(path)).unwrap();
+                let archive = Archive::open(black_box(path)).unwrap();
                 for filename in filenames.iter() {
                     let data = archive.read_file(filename).unwrap();
                     black_box(data);
@@ -249,7 +249,7 @@ fn bench_random_access(c: &mut Criterion) {
         &(&archive_path, &random),
         |b, (path, filenames)| {
             b.iter(|| {
-                let mut archive = Archive::open(black_box(path)).unwrap();
+                let archive = Archive::open(black_box(path)).unwrap();
                 for filename in filenames.iter() {
                     let data = archive.read_file(filename).unwrap();
                     black_box(data);
@@ -291,7 +291,7 @@ fn bench_version_extraction(c: &mut Criterion) {
             &archive_path,
             |b, path| {
                 b.iter(|| {
-                    let mut archive = Archive::open(black_box(path)).unwrap();
+                    let archive = Archive::open(black_box(path)).unwrap();
                     let extracted = archive.read_file("test.dat").unwrap();
                     black_box(extracted);
                 });
@@ -332,7 +332,7 @@ fn bench_parallel_extraction(c: &mut Criterion) {
     // Single-threaded baseline
     group.bench_function("single_thread", |b| {
         b.iter(|| {
-            let mut archive = Archive::open(black_box(&archive_path)).unwrap();
+            let archive = Archive::open(black_box(&archive_path)).unwrap();
             for i in 0..file_count {
                 let filename = format!("file_{i:02}.dat");
                 let data = archive.read_file(&filename).unwrap();

--- a/file-formats/archives/wow-mpq/benches/parallel_processing.rs
+++ b/file-formats/archives/wow-mpq/benches/parallel_processing.rs
@@ -57,7 +57,7 @@ fn bench_multi_archive_extraction(c: &mut Criterion) {
                 b.iter(|| {
                     let mut results = Vec::new();
                     for path in archives.iter() {
-                        let mut archive = Archive::open(black_box(path)).unwrap();
+                        let archive = Archive::open(black_box(path)).unwrap();
                         let data = archive.read_file("file_005.txt").unwrap();
                         results.push((path.clone(), data));
                     }
@@ -99,7 +99,7 @@ fn bench_multi_archive_search(c: &mut Criterion) {
         b.iter(|| {
             let mut results = Vec::new();
             for path in archives.iter() {
-                let mut archive = Archive::open(black_box(path)).unwrap();
+                let archive = Archive::open(black_box(path)).unwrap();
                 let files = archive.list().unwrap();
                 let matching: Vec<String> = files
                     .into_iter()
@@ -145,7 +145,7 @@ fn bench_multi_file_multi_archive(c: &mut Criterion) {
         b.iter(|| {
             let mut results = Vec::new();
             for path in archives.iter() {
-                let mut archive = Archive::open(black_box(path)).unwrap();
+                let archive = Archive::open(black_box(path)).unwrap();
                 let mut file_results = Vec::new();
                 for &file_name in &files_to_extract {
                     let data = archive.read_file(file_name).unwrap();
@@ -184,7 +184,7 @@ fn bench_custom_processing(c: &mut Criterion) {
         b.iter(|| {
             let mut counts = Vec::new();
             for path in archives.iter() {
-                let mut archive = Archive::open(black_box(path)).unwrap();
+                let archive = Archive::open(black_box(path)).unwrap();
                 let count = archive.list().unwrap().len();
                 counts.push(count);
             }
@@ -196,7 +196,7 @@ fn bench_custom_processing(c: &mut Criterion) {
     group.bench_function("parallel_count", |b| {
         b.iter(|| {
             use wow_mpq::parallel::process_archives_parallel;
-            let counts = process_archives_parallel(black_box(&archives), |mut archive| {
+            let counts = process_archives_parallel(black_box(&archives), |archive| {
                 Ok(archive.list()?.len())
             })
             .unwrap();

--- a/file-formats/archives/wow-mpq/benches/phase1_demo.rs
+++ b/file-formats/archives/wow-mpq/benches/phase1_demo.rs
@@ -27,7 +27,7 @@ fn demonstrate_phase1_performance(c: &mut Criterion) {
             // Benchmark archive opening and listing
             group.bench_function(format!("list_{}", archive_name), |b| {
                 b.iter(|| {
-                    if let Ok(mut archive) = wow_mpq::Archive::open(archive_path) {
+                    if let Ok(archive) = wow_mpq::Archive::open(archive_path) {
                         let _ = archive.list().unwrap_or_default();
                     }
                 })
@@ -47,7 +47,7 @@ fn measure_listing_performance(archive_path: &str, archive_name: &str) {
     // Measure archive opening time
     let open_start = Instant::now();
     match wow_mpq::Archive::open(archive_path) {
-        Ok(mut archive) => {
+        Ok(archive) => {
             let open_duration = open_start.elapsed();
 
             // Measure file listing time

--- a/file-formats/archives/wow-mpq/benches/production_performance.rs
+++ b/file-formats/archives/wow-mpq/benches/production_performance.rs
@@ -121,7 +121,7 @@ fn bench_throughput_scaling(c: &mut Criterion) {
 
         // Generate file list for extraction (extract all files)
         let files: Vec<String> = {
-            let mut archive = Archive::open(&archive_path).unwrap();
+            let archive = Archive::open(&archive_path).unwrap();
             archive
                 .list()
                 .unwrap()
@@ -137,7 +137,7 @@ fn bench_throughput_scaling(c: &mut Criterion) {
             &(&archive_path, &file_refs, total_bytes),
             |b, (path, files, _bytes)| {
                 b.iter(|| {
-                    let mut archive = Archive::open(black_box(path)).unwrap();
+                    let archive = Archive::open(black_box(path)).unwrap();
                     let mut results = Vec::new();
                     for &file in files.iter() {
                         let data = archive.read_file(file).unwrap();
@@ -190,7 +190,7 @@ fn bench_threading_scalability(c: &mut Criterion) {
         create_test_archive_realistic("threading_test", 2000, 100, 0.6);
 
     let files: Vec<String> = {
-        let mut archive = Archive::open(&archive_path).unwrap();
+        let archive = Archive::open(&archive_path).unwrap();
         archive
             .list()
             .unwrap()
@@ -233,7 +233,7 @@ fn bench_batch_size_optimization(c: &mut Criterion) {
     let (_temp_dir, archive_path, _) = create_test_archive_realistic("batch_test", 1500, 80, 0.4);
 
     let files: Vec<String> = {
-        let mut archive = Archive::open(&archive_path).unwrap();
+        let archive = Archive::open(&archive_path).unwrap();
         archive
             .list()
             .unwrap()
@@ -277,7 +277,7 @@ fn bench_resource_utilization(c: &mut Criterion) {
         create_test_archive_realistic("resource_test", 10000, 120, 0.7);
 
     let files: Vec<String> = {
-        let mut archive = Archive::open(&archive_path).unwrap();
+        let archive = Archive::open(&archive_path).unwrap();
         archive
             .list()
             .unwrap()
@@ -340,7 +340,7 @@ fn bench_realistic_wow_archive(c: &mut Criterion) {
                         let mpq_path = entry.path();
 
                         // Try to open and get file count
-                        if let Ok(mut archive) = Archive::open(&mpq_path) {
+                        if let Ok(archive) = Archive::open(&mpq_path) {
                             if let Ok(file_list) = archive.list() {
                                 let file_count = file_list.len();
 
@@ -409,7 +409,7 @@ fn bench_stress_no_hanging(c: &mut Criterion) {
     );
 
     let files: Vec<String> = {
-        let mut archive = Archive::open(&archive_path).unwrap();
+        let archive = Archive::open(&archive_path).unwrap();
         archive
             .list()
             .unwrap()
@@ -456,7 +456,7 @@ fn bench_individual_vs_bulk(c: &mut Criterion) {
     let (_temp_dir, archive_path, _) = create_test_archive_realistic("comparison", 500, 150, 0.4);
 
     let files: Vec<String> = {
-        let mut archive = Archive::open(&archive_path).unwrap();
+        let archive = Archive::open(&archive_path).unwrap();
         archive
             .list()
             .unwrap()
@@ -472,7 +472,7 @@ fn bench_individual_vs_bulk(c: &mut Criterion) {
         b.iter(|| {
             let mut results = Vec::new();
             for &file in file_refs.iter() {
-                let mut archive = Archive::open(black_box(&archive_path)).unwrap();
+                let archive = Archive::open(black_box(&archive_path)).unwrap();
                 let data = archive.read_file(file).unwrap();
                 results.push(data);
             }
@@ -483,7 +483,7 @@ fn bench_individual_vs_bulk(c: &mut Criterion) {
     // Sequential bulk extraction (one handle, multiple files)
     group.bench_function("sequential_bulk", |b| {
         b.iter(|| {
-            let mut archive = Archive::open(black_box(&archive_path)).unwrap();
+            let archive = Archive::open(black_box(&archive_path)).unwrap();
             let mut results = Vec::new();
             for &file in file_refs.iter() {
                 let data = archive.read_file(file).unwrap();

--- a/file-formats/archives/wow-mpq/benches/single_archive_parallel.rs
+++ b/file-formats/archives/wow-mpq/benches/single_archive_parallel.rs
@@ -53,7 +53,7 @@ fn bench_multiple_file_extraction(c: &mut Criterion) {
         // Sequential extraction
         group.bench_with_input(BenchmarkId::new("sequential", count), &files, |b, files| {
             b.iter(|| {
-                let mut archive = Archive::open(black_box(&archive_path)).unwrap();
+                let archive = Archive::open(black_box(&archive_path)).unwrap();
                 let mut results = Vec::new();
                 for &file in files.iter() {
                     let data = archive.read_file(file).unwrap();
@@ -103,7 +103,7 @@ fn bench_pattern_matching(c: &mut Criterion) {
     // Sequential pattern matching
     group.bench_function("sequential", |b| {
         b.iter(|| {
-            let mut archive = Archive::open(black_box(&archive_path)).unwrap();
+            let archive = Archive::open(black_box(&archive_path)).unwrap();
             let files = archive.list().unwrap();
             let mut results = Vec::new();
 
@@ -152,7 +152,7 @@ fn bench_file_size_impact(c: &mut Criterion) {
             &files,
             |b, files| {
                 b.iter(|| {
-                    let mut archive = Archive::open(black_box(&archive_path)).unwrap();
+                    let archive = Archive::open(black_box(&archive_path)).unwrap();
                     let mut results = Vec::new();
                     for &file in files.iter() {
                         let data = archive.read_file(file).unwrap();
@@ -224,7 +224,7 @@ fn bench_parallel_overhead(c: &mut Criterion) {
 
     group.bench_function("sequential_small", |b| {
         b.iter(|| {
-            let mut archive = Archive::open(black_box(&archive_path)).unwrap();
+            let archive = Archive::open(black_box(&archive_path)).unwrap();
             let mut results = Vec::new();
             for &file in small_files.iter() {
                 let data = archive.read_file(file).unwrap();
@@ -251,7 +251,7 @@ fn bench_parallel_overhead(c: &mut Criterion) {
 
     group.bench_function("sequential_large", |b| {
         b.iter(|| {
-            let mut archive = Archive::open(black_box(&archive_path)).unwrap();
+            let archive = Archive::open(black_box(&archive_path)).unwrap();
             let mut results = Vec::new();
             for &file in large_files.iter() {
                 let data = archive.read_file(file).unwrap();
@@ -286,7 +286,7 @@ fn bench_custom_processing(c: &mut Criterion) {
     // Sequential processing
     group.bench_function("sequential_checksum", |b| {
         b.iter(|| {
-            let mut archive = Archive::open(black_box(&archive_path)).unwrap();
+            let archive = Archive::open(black_box(&archive_path)).unwrap();
             let mut results = Vec::new();
 
             for &file in files.iter() {

--- a/file-formats/archives/wow-mpq/examples/analyze_attributes.rs
+++ b/file-formats/archives/wow-mpq/examples/analyze_attributes.rs
@@ -3,7 +3,7 @@ use wow_mpq::Archive;
 fn analyze_attributes(path: &str, name: &str) -> Result<(), Box<dyn std::error::Error>> {
     println!("\n=== Analyzing {name} attributes file ===");
 
-    let mut archive = Archive::open(path)?;
+    let archive = Archive::open(path)?;
 
     match archive.read_file("(attributes)") {
         Ok(data) => {

--- a/file-formats/archives/wow-mpq/examples/bulk_modify.rs
+++ b/file-formats/archives/wow-mpq/examples/bulk_modify.rs
@@ -149,7 +149,7 @@ fn bulk_modify_archive(path: &str) -> Result<(), Box<dyn Error>> {
 }
 
 fn list_archive_details(path: &str) -> Result<(), Box<dyn Error>> {
-    let mut archive = Archive::open(path)?;
+    let archive = Archive::open(path)?;
     let files = archive.list_all()?;
 
     println!("\nTotal files: {}", files.len());

--- a/file-formats/archives/wow-mpq/examples/create_archive.rs
+++ b/file-formats/archives/wow-mpq/examples/create_archive.rs
@@ -76,7 +76,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for archive_name in &["simple.mpq", "from_files.mpq", "custom.mpq"] {
         println!("\nChecking {archive_name}:");
 
-        let mut archive = Archive::open(archive_name)?;
+        let archive = Archive::open(archive_name)?;
 
         // Try to list files
         match archive.list() {

--- a/file-formats/archives/wow-mpq/examples/list_archive_contents.rs
+++ b/file-formats/archives/wow-mpq/examples/list_archive_contents.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     for archive_path in &archives {
         println!("\n=== Contents of {archive_path} ===");
 
-        let mut archive = Archive::open(archive_path)?;
+        let archive = Archive::open(archive_path)?;
         let files = archive.list_all()?;
 
         println!("Total files: {}", files.len());

--- a/file-formats/archives/wow-mpq/examples/list_with_names.rs
+++ b/file-formats/archives/wow-mpq/examples/list_with_names.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Archive Listing with Proper Names ===");
     println!("Archive: {archive_path}");
 
-    let mut archive = Archive::open(archive_path)?;
+    let archive = Archive::open(archive_path)?;
 
     // First try to list files using the listfile (gets proper names)
     match archive.list() {

--- a/file-formats/archives/wow-mpq/examples/modify_archive.rs
+++ b/file-formats/archives/wow-mpq/examples/modify_archive.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Verify changes by reopening in read-only mode
     println!("\n🔍 Verifying changes...");
-    let mut readonly = wow_mpq::Archive::open(archive_path)?;
+    let readonly = wow_mpq::Archive::open(archive_path)?;
 
     let files = readonly.list()?;
     println!("\nFiles in modified archive:");

--- a/file-formats/archives/wow-mpq/examples/performance_analysis.rs
+++ b/file-formats/archives/wow-mpq/examples/performance_analysis.rs
@@ -127,7 +127,7 @@ fn test_threading_scalability() -> Result<Vec<PerformanceMetrics>> {
         create_test_archive("threading_test", 1000, 100, 0.5)?;
 
     let files: Vec<String> = {
-        let mut archive = Archive::open(&archive_path)?;
+        let archive = Archive::open(&archive_path)?;
         archive.list()?.into_iter().map(|e| e.name).collect()
     };
     let file_refs: Vec<&str> = files.iter().map(|s| s.as_str()).collect();
@@ -171,7 +171,7 @@ fn test_batch_size_optimization() -> Result<Vec<PerformanceMetrics>> {
     let (_temp_dir, archive_path, total_bytes) = create_test_archive("batch_test", 800, 80, 0.4)?;
 
     let files: Vec<String> = {
-        let mut archive = Archive::open(&archive_path)?;
+        let archive = Archive::open(&archive_path)?;
         archive.list()?.into_iter().map(|e| e.name).collect()
     };
     let file_refs: Vec<&str> = files.iter().map(|s| s.as_str()).collect();
@@ -226,7 +226,7 @@ fn test_archive_size_scaling() -> Result<Vec<PerformanceMetrics>> {
             create_test_archive(&name.to_lowercase(), file_count, avg_size_kb, 0.6)?;
 
         let files: Vec<String> = {
-            let mut archive = Archive::open(&archive_path)?;
+            let archive = Archive::open(&archive_path)?;
             archive.list()?.into_iter().map(|e| e.name).collect()
         };
         let file_refs: Vec<&str> = files.iter().map(|s| s.as_str()).collect();
@@ -235,7 +235,7 @@ fn test_archive_size_scaling() -> Result<Vec<PerformanceMetrics>> {
 
         // Sequential
         let start = Instant::now();
-        let mut archive = Archive::open(&archive_path)?;
+        let archive = Archive::open(&archive_path)?;
         let mut sequential_results = Vec::new();
         for &file in &file_refs {
             let data = archive.read_file(file)?;
@@ -294,7 +294,7 @@ fn test_no_hanging_stress() -> Result<PerformanceMetrics> {
     )?;
 
     let files: Vec<String> = {
-        let mut archive = Archive::open(&archive_path)?;
+        let archive = Archive::open(&archive_path)?;
         archive.list()?.into_iter().map(|e| e.name).collect()
     };
     let file_refs: Vec<&str> = files.iter().map(|s| s.as_str()).collect();
@@ -336,7 +336,7 @@ fn test_individual_vs_bulk() -> Result<Vec<PerformanceMetrics>> {
     let (_temp_dir, archive_path, total_bytes) = create_test_archive("comparison", 200, 150, 0.4)?;
 
     let files: Vec<String> = {
-        let mut archive = Archive::open(&archive_path)?;
+        let archive = Archive::open(&archive_path)?;
         archive
             .list()?
             .into_iter()
@@ -353,7 +353,7 @@ fn test_individual_vs_bulk() -> Result<Vec<PerformanceMetrics>> {
     let start = Instant::now();
     let mut individual_results = Vec::new();
     for &file in &file_refs {
-        let mut archive = Archive::open(&archive_path)?;
+        let archive = Archive::open(&archive_path)?;
         let data = archive.read_file(file)?;
         individual_results.push(data);
     }
@@ -372,7 +372,7 @@ fn test_individual_vs_bulk() -> Result<Vec<PerformanceMetrics>> {
 
     // Sequential bulk extraction (one handle, multiple files)
     let start = Instant::now();
-    let mut archive = Archive::open(&archive_path)?;
+    let archive = Archive::open(&archive_path)?;
     let mut sequential_results = Vec::new();
     for &file in &file_refs {
         let data = archive.read_file(file)?;

--- a/file-formats/archives/wow-mpq/examples/performance_demo.rs
+++ b/file-formats/archives/wow-mpq/examples/performance_demo.rs
@@ -72,7 +72,7 @@ fn measure_archive_performance(archive_path: &str, description: &str) -> Option<
     println!("Testing: {}", description);
 
     let open_start = Instant::now();
-    let mut archive = match Archive::open(archive_path) {
+    let archive = match Archive::open(archive_path) {
         Ok(archive) => archive,
         Err(e) => {
             println!("  ❌ Failed to open: {}\n", e);

--- a/file-formats/archives/wow-mpq/examples/real_wow_test.rs
+++ b/file-formats/archives/wow-mpq/examples/real_wow_test.rs
@@ -16,7 +16,7 @@ fn test_real_wow_archive(archive_path: &str) -> Result<()> {
     }
 
     // Open archive and get file list
-    let mut archive = Archive::open(path)?;
+    let archive = Archive::open(path)?;
     let file_list = archive.list()?;
     println!("📊 Archive contains {} files", file_list.len());
 
@@ -48,7 +48,7 @@ fn test_real_wow_archive(archive_path: &str) -> Result<()> {
     let mut sequential_count = 0;
     for &file in file_refs.iter().take(50) {
         // Small subset for sequential test
-        let mut archive = Archive::open(path)?;
+        let archive = Archive::open(path)?;
         if archive.read_file(file).is_ok() {
             sequential_count += 1;
         }

--- a/file-formats/archives/wow-mpq/examples/simple_list.rs
+++ b/file-formats/archives/wow-mpq/examples/simple_list.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Simple Archive Listing ===");
     println!("Archive: {archive_path}");
 
-    let mut archive = Archive::open(archive_path)?;
+    let archive = Archive::open(archive_path)?;
     let files = archive.list()?;
 
     println!("Found {} files:", files.len());

--- a/file-formats/archives/wow-mpq/examples/stress_test_hanging.rs
+++ b/file-formats/archives/wow-mpq/examples/stress_test_hanging.rs
@@ -54,7 +54,7 @@ fn test_no_hanging() -> Result<()> {
 
     // Get all files in archive
     let files: Vec<String> = {
-        let mut archive = Archive::open(&archive_path)?;
+        let archive = Archive::open(&archive_path)?;
         archive.list()?.into_iter().map(|e| e.name).collect()
     };
     let file_refs: Vec<&str> = files.iter().map(|s| s.as_str()).collect();
@@ -111,7 +111,7 @@ fn test_resource_usage() -> Result<()> {
 
     // Get subset of files to test different configurations
     let files: Vec<String> = {
-        let mut archive = Archive::open(&archive_path)?;
+        let archive = Archive::open(&archive_path)?;
         archive
             .list()?
             .into_iter()
@@ -175,7 +175,7 @@ fn test_edge_cases() -> Result<()> {
 
     // Get all files
     let all_files: Vec<String> = {
-        let mut archive = Archive::open(&archive_path)?;
+        let archive = Archive::open(&archive_path)?;
         archive.list()?.into_iter().map(|e| e.name).collect()
     };
 

--- a/file-formats/archives/wow-mpq/examples/verify_wow_files.rs
+++ b/file-formats/archives/wow-mpq/examples/verify_wow_files.rs
@@ -104,7 +104,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Verify the files
     println!("\nVerifying files...");
-    let mut archive = Archive::open(test_archive)?;
+    let archive = Archive::open(test_archive)?;
     let mut all_match = true;
 
     for (filename, original_data) in &test_files {

--- a/file-formats/archives/wow-mpq/src/database/import.rs
+++ b/file-formats/archives/wow-mpq/src/database/import.rs
@@ -114,7 +114,7 @@ impl<'a> Importer<'a> {
     /// Import from an MPQ archive
     fn import_archive(&self, path: &Path) -> ImportResult<ImportStats> {
         let mut stats = ImportStats::default();
-        let mut archive = Archive::open(path)?;
+        let archive = Archive::open(path)?;
         let source = format!("archive:{}", path.display());
 
         // Get list of files from the archive

--- a/file-formats/archives/wow-mpq/src/lib.rs
+++ b/file-formats/archives/wow-mpq/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! # fn main() -> Result<(), wow_mpq::Error> {
 //! // Open an existing MPQ archive
-//! let mut archive = Archive::open("example.mpq")?;
+//! let archive = Archive::open("example.mpq")?;
 //!
 //! // List files in the archive
 //! for entry in archive.list()? {

--- a/file-formats/archives/wow-mpq/src/parallel.rs
+++ b/file-formats/archives/wow-mpq/src/parallel.rs
@@ -38,7 +38,7 @@ pub fn extract_from_multiple_archives<P: AsRef<Path> + Sync>(
         .map(|path| {
             let path_ref = path.as_ref();
             match Archive::open(path_ref) {
-                Ok(mut archive) => match archive.read_file(file_name) {
+                Ok(archive) => match archive.read_file(file_name) {
                     Ok(data) => Ok((path_ref.to_path_buf(), data)),
                     Err(e) => Err(e),
                 },
@@ -86,7 +86,7 @@ pub fn extract_multiple_from_multiple_archives<P: AsRef<Path> + Sync>(
         .par_iter()
         .map(|path| {
             let path_ref = path.as_ref();
-            let mut archive = Archive::open(path_ref)?;
+            let archive = Archive::open(path_ref)?;
 
             let files: Result<Vec<_>> = file_names
                 .iter()
@@ -129,7 +129,7 @@ pub fn search_in_multiple_archives<P: AsRef<Path> + Sync>(
         .par_iter()
         .map(|path| {
             let path_ref = path.as_ref();
-            let mut archive = Archive::open(path_ref)?;
+            let archive = Archive::open(path_ref)?;
             let files = archive.list()?;
 
             let matching: Vec<String> = files
@@ -157,7 +157,7 @@ pub fn search_in_multiple_archives<P: AsRef<Path> + Sync>(
 /// let archives = vec!["data.mpq", "patch.mpq"];
 ///
 /// // Count files in each archive
-/// let counts = process_archives_parallel(&archives, |mut archive| {
+/// let counts = process_archives_parallel(&archives, |archive| {
 ///     Ok(archive.list()?.len())
 /// })?;
 ///
@@ -252,7 +252,7 @@ mod tests {
         let (_temp_dir, archives) = create_test_archives(3)?;
 
         // Count files in each archive
-        let counts = process_archives_parallel(&archives, |mut archive| Ok(archive.list()?.len()))?;
+        let counts = process_archives_parallel(&archives, |archive| Ok(archive.list()?.len()))?;
 
         assert_eq!(counts.len(), 3);
         for count in counts {

--- a/file-formats/archives/wow-mpq/src/path.rs
+++ b/file-formats/archives/wow-mpq/src/path.rs
@@ -25,7 +25,7 @@
 //!
 //! // When reading, both separators work
 //! # use wow_mpq::Archive;
-//! # let mut archive = Archive::open("test.mpq").unwrap();
+//! # let archive = Archive::open("test.mpq").unwrap();
 //! let data1 = archive.read_file("dir/subdir/file.txt").unwrap();
 //! let data2 = archive.read_file("dir\\subdir\\file.txt").unwrap();
 //! assert_eq!(data1, data2);

--- a/file-formats/archives/wow-mpq/src/rebuild.rs
+++ b/file-formats/archives/wow-mpq/src/rebuild.rs
@@ -366,8 +366,8 @@ fn is_signature_file(filename: &str) -> bool {
 
 /// Verify that the rebuilt archive matches the original
 fn verify_rebuild(source_path: &Path, target_path: &Path, options: &RebuildOptions) -> Result<()> {
-    let mut source_archive = Archive::open(source_path)?;
-    let mut target_archive = Archive::open(target_path)?;
+    let source_archive = Archive::open(source_path)?;
+    let target_archive = Archive::open(target_path)?;
 
     let source_files = source_archive
         .list()

--- a/file-formats/archives/wow-mpq/src/single_archive_parallel.rs
+++ b/file-formats/archives/wow-mpq/src/single_archive_parallel.rs
@@ -49,7 +49,7 @@ impl ParallelArchive {
         let path = path.as_ref().to_path_buf();
 
         // Open archive and get file list
-        let mut archive = Archive::open(&path)?;
+        let archive = Archive::open(&path)?;
         let entries = archive.list()?;
         let file_list = Arc::new(entries.into_iter().map(|e| e.name).collect());
 
@@ -119,7 +119,7 @@ impl ParallelArchive {
     /// a new file handle, avoiding conflicts with other threads.
     pub fn read_file_with_new_handle(&self, filename: &str) -> Result<Vec<u8>> {
         // Open a new file handle for this thread
-        let mut archive = Archive::open(&self.path)?;
+        let archive = Archive::open(&self.path)?;
 
         // Read the file
         archive.read_file(filename)
@@ -152,7 +152,7 @@ impl ParallelArchive {
             .par_iter()
             .map(|chunk| {
                 // Open one archive handle per batch
-                let mut archive = Archive::open(&self.path)?;
+                let archive = Archive::open(&self.path)?;
 
                 // Extract all files in this batch
                 let mut batch_results = Vec::new();
@@ -277,7 +277,7 @@ fn extract_with_config_batched<P: AsRef<Path>>(
             .par_iter()
             .map(|chunk| {
                 // Open one archive handle per batch to limit resource usage
-                let mut archive_handle = Archive::open(archive.path.as_path())?;
+                let archive_handle = Archive::open(archive.path.as_path())?;
 
                 // Process all files in this batch with the same handle
                 let mut batch_results = Vec::with_capacity(chunk.len());

--- a/file-formats/archives/wow-mpq/tests/compliance/stormlib/stormlib_compatibility.rs
+++ b/file-formats/archives/wow-mpq/tests/compliance/stormlib/stormlib_compatibility.rs
@@ -26,7 +26,7 @@ fn test_compression_byte_prefix() {
     builder.build(&archive_path).unwrap();
 
     // Open the archive and read the file
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let file_data = archive.read_file("test.dat").unwrap();
     assert_eq!(file_data, test_data);
 
@@ -61,7 +61,7 @@ fn test_multi_compression_format() {
     builder.build(&archive_path).unwrap();
 
     // Open the archive and read the file
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let file_data = archive.read_file("audio.wav").unwrap();
 
     // ADPCM is lossy, so we just check the size is correct
@@ -94,7 +94,7 @@ fn test_uncompressed_small_data() {
     builder.build(&archive_path).unwrap();
 
     // Open the archive and read the file
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let file_data = archive.read_file("small.txt").unwrap();
     assert_eq!(file_data, test_data);
 

--- a/file-formats/archives/wow-mpq/tests/component/security/crc.rs
+++ b/file-formats/archives/wow-mpq/tests/component/security/crc.rs
@@ -36,7 +36,7 @@ fn test_valid_crc_extraction() {
         return;
     }
 
-    let mut archive = Archive::open(test_file).expect("Failed to open test archive");
+    let archive = Archive::open(test_file).expect("Failed to open test archive");
 
     // This should succeed with valid CRCs
     let data = archive
@@ -64,7 +64,7 @@ fn test_single_unit_crc() {
         return;
     }
 
-    let mut archive = Archive::open(test_file).expect("Failed to open test archive");
+    let archive = Archive::open(test_file).expect("Failed to open test archive");
 
     // This should succeed with valid CRC
     let data = archive

--- a/file-formats/archives/wow-mpq/tests/component/security/crc_generation.rs
+++ b/file-formats/archives/wow-mpq/tests/component/security/crc_generation.rs
@@ -25,7 +25,7 @@ fn test_single_unit_file_crc_generation() {
         .unwrap();
 
     // Open and verify the archive
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
 
     // Read the file - this should validate the CRC
     let read_data = archive.read_file("small.txt").unwrap();
@@ -63,7 +63,7 @@ fn test_multi_sector_file_crc_generation() {
         .unwrap();
 
     // Open and verify the archive
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
 
     // Read the file - this should validate the CRCs for all sectors
     let read_data = archive.read_file("large.bin").unwrap();
@@ -97,7 +97,7 @@ fn test_no_crc_generation() {
         .unwrap();
 
     // Open and verify the archive
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
 
     // Read the file
     let read_data = archive.read_file("no_crc.txt").unwrap();
@@ -134,7 +134,7 @@ fn test_crc_generation_with_compression() {
         .unwrap();
 
     // Open and verify the archive
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
 
     // Read the file - this should decompress and validate CRC
     let read_data = archive.read_file("compressible.txt").unwrap();
@@ -176,7 +176,7 @@ fn test_crc_generation_with_encryption() {
         .unwrap();
 
     // Open and verify the archive
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
 
     // Read the file - this should decrypt and validate CRC
     let read_data = archive.read_file("secret.dat").unwrap();

--- a/file-formats/archives/wow-mpq/tests/component/tables/het_bet.rs
+++ b/file-formats/archives/wow-mpq/tests/component/tables/het_bet.rs
@@ -85,7 +85,7 @@ fn test_v3_archive_with_classic_table_compatibility() {
         .expect("Failed to create archive");
 
     // Open and verify
-    let mut archive = Archive::open(&archive_path).expect("Failed to open archive");
+    let archive = Archive::open(&archive_path).expect("Failed to open archive");
 
     // V3 archives may have table offset issues, but should still work via classic tables
     // HET/BET tables may not load due to swapped offsets detection

--- a/file-formats/archives/wow-mpq/tests/integration/archive/builder.rs
+++ b/file-formats/archives/wow-mpq/tests/integration/archive/builder.rs
@@ -42,7 +42,7 @@ fn test_create_archive_with_files() {
         .unwrap();
 
     // Verify archive contents
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
 
     // Check that files exist
     assert!(archive.find_file("test/file1.txt").unwrap().is_some());
@@ -69,7 +69,7 @@ fn test_create_archive_with_memory_files() {
         .unwrap();
 
     // Verify contents
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
 
     let data1 = archive.read_file("mem1.txt").unwrap();
     assert_eq!(data1, b"Memory file 1");
@@ -92,7 +92,7 @@ fn test_listfile_generation() {
         .unwrap();
 
     // Verify listfile exists and contains expected entries
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
 
     let listfile_data = archive.read_file("(listfile)").unwrap();
     let listfile_content = String::from_utf8(listfile_data).unwrap();
@@ -125,7 +125,7 @@ fn test_external_listfile() {
         .unwrap();
 
     // Verify listfile contains external content
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
 
     let listfile_data = archive.read_file("(listfile)").unwrap();
     let listfile_content = String::from_utf8(listfile_data).unwrap();
@@ -173,7 +173,7 @@ fn test_compression_options() {
         assert!(file_info.compressed_size < file_info.file_size);
 
         // Verify we can still read it correctly
-        let mut archive = Archive::open(&archive_path).unwrap();
+        let archive = Archive::open(&archive_path).unwrap();
         let read_data = archive.read_file("compressed.txt").unwrap();
         assert_eq!(read_data, data.as_bytes());
     } else {
@@ -225,7 +225,7 @@ fn test_large_file_sectors() {
         .unwrap();
 
     // Verify we can read it back correctly
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let read_data = archive.read_file("large.dat").unwrap();
     assert_eq!(read_data, large_data);
 }
@@ -247,7 +247,7 @@ fn test_hash_table_sizing() {
     builder.build(&archive_path).unwrap();
 
     // Verify all files can be found
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     for i in 0..50 {
         let filename = format!("file_{i:03}.txt");
         assert!(archive.find_file(&filename).unwrap().is_some());
@@ -412,7 +412,7 @@ fn test_encrypted_file_round_trip() {
     }
 
     // Verify we can decrypt and read it correctly
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let decrypted_data = archive.read_file("secret.txt").unwrap();
     assert_eq!(decrypted_data, test_data);
 }
@@ -447,7 +447,7 @@ fn test_encrypted_file_with_fix_key() {
     }
 
     // Verify we can decrypt and read it correctly
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let decrypted_data = archive.read_file("fix_key.dat").unwrap();
     assert_eq!(decrypted_data, test_data);
 }
@@ -484,7 +484,7 @@ fn test_encrypted_large_file() {
     }
 
     // Verify we can decrypt and read it correctly
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let decrypted_data = archive.read_file("large_encrypted.bin").unwrap();
     assert_eq!(decrypted_data, large_data);
 }
@@ -515,7 +515,7 @@ fn test_mixed_encrypted_and_plain_files() {
         .unwrap();
 
     // Open archive and verify all files
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
 
     // Check plain file
     let plain_info = archive.find_file("plain.txt").unwrap().unwrap();
@@ -569,7 +569,7 @@ fn test_encrypted_compressed_file() {
     }
 
     // Verify we can decrypt and decompress correctly
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let decrypted_data = archive.read_file("encrypted_compressed.txt").unwrap();
     assert_eq!(decrypted_data, data.as_bytes());
 }
@@ -595,7 +595,7 @@ fn test_hi_block_table_creation_v2() {
     assert!(archive.header().hi_block_table_pos.is_some());
 
     // Verify files can be read
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let data1 = archive.read_file("test.txt").unwrap();
     assert_eq!(data1, b"Test data for V2");
     let data2 = archive.read_file("file2.txt").unwrap();
@@ -626,7 +626,7 @@ fn test_hi_block_table_creation_v3() {
     assert!(archive.header().archive_size_64.is_some());
 
     // Verify files
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let data1 = archive.read_file("test.txt").unwrap();
     assert_eq!(data1, b"Test data for V3");
     let data2 = archive.read_file("advanced.txt").unwrap();

--- a/file-formats/archives/wow-mpq/tests/integration/archive/listfile_modification.rs
+++ b/file-formats/archives/wow-mpq/tests/integration/archive/listfile_modification.rs
@@ -22,7 +22,7 @@ fn test_listfile_updates_correctly() {
 
     // Open and verify initial contents
     {
-        let mut archive = Archive::open(path).unwrap();
+        let archive = Archive::open(path).unwrap();
         let files = archive.list().unwrap();
         assert_eq!(files.len(), 3); // 2 files + listfile
 
@@ -60,7 +60,7 @@ fn test_listfile_updates_correctly() {
 
     // Reopen and verify all files are listed
     {
-        let mut archive = Archive::open(path).unwrap();
+        let archive = Archive::open(path).unwrap();
         let files = archive.list().unwrap();
 
         // Should have 5 files now: file1.txt, file2.txt, file3.txt, file4.txt, (listfile)

--- a/file-formats/archives/wow-mpq/tests/integration/archive/modification.rs
+++ b/file-formats/archives/wow-mpq/tests/integration/archive/modification.rs
@@ -57,7 +57,7 @@ fn test_add_file_from_disk() {
     drop(mutable_archive);
 
     // Verify file was added
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     assert_eq!(archive.list().unwrap().len(), 5); // 4 + new file
 
     let content = archive.read_file("new_file.txt").unwrap();
@@ -84,7 +84,7 @@ fn test_add_file_from_memory() {
     drop(mutable_archive);
 
     // Verify file was added
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let files = archive.list().unwrap();
 
     println!("Files in archive:");
@@ -132,7 +132,7 @@ fn test_remove_file() {
     drop(mutable_archive);
 
     // Verify file was removed
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let files = archive.list().unwrap();
     assert!(!files.iter().any(|f| f.name == "file1.txt"));
 }
@@ -152,7 +152,7 @@ fn test_rename_file() {
     drop(mutable_archive);
 
     // Verify file was renamed
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let files = archive.list().unwrap();
     assert!(!files.iter().any(|f| f.name == "dir\\file2.txt"));
     assert!(files.iter().any(|f| f.name == "renamed\\file2.txt"));
@@ -179,7 +179,7 @@ fn test_replace_existing_file() {
     drop(mutable_archive);
 
     // Verify file was replaced
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let content = archive.read_file("file1.txt").unwrap();
     assert_eq!(content, b"Replaced content");
 }
@@ -246,7 +246,7 @@ fn test_compact_archive() {
     assert!(compacted_size < fragmented_size);
 
     // Verify all remaining files are still accessible
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     assert_eq!(archive.read_file("file1.txt").unwrap(), b"Test content 1");
     assert_eq!(
         archive.read_file("big2.dat").unwrap(),
@@ -275,7 +275,7 @@ fn test_path_normalization() {
     drop(mutable_archive);
 
     // Should be accessible with backslashes
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let content = archive.read_file("path\\to\\file.txt").unwrap();
     assert_eq!(content, b"Forward slash content");
 }

--- a/file-formats/archives/wow-mpq/tests/integration/archive/test_debug_add.rs
+++ b/file-formats/archives/wow-mpq/tests/integration/archive/test_debug_add.rs
@@ -17,7 +17,7 @@ fn test_debug_add_file() {
 
     // Check initial state and print header info
     {
-        let mut archive = Archive::open(&archive_path).unwrap();
+        let archive = Archive::open(&archive_path).unwrap();
         let header = archive.header();
         println!("Initial header info:");
         println!("  Format version: {:?}", header.format_version);
@@ -71,7 +71,7 @@ fn test_debug_add_file() {
     // Check final state
     {
         println!("\nReopening archive to check changes...");
-        let mut archive = Archive::open(&archive_path).unwrap();
+        let archive = Archive::open(&archive_path).unwrap();
         let header = archive.header();
         println!("Final header info:");
         println!("  Format version: {:?}", header.format_version);

--- a/file-formats/archives/wow-mpq/tests/integration/archive/test_encryption_keys.rs
+++ b/file-formats/archives/wow-mpq/tests/integration/archive/test_encryption_keys.rs
@@ -44,7 +44,7 @@ fn test_encryption_key_diagnosis() {
 
     // Now read back and check key calculation
     {
-        let mut archive = Archive::open(&archive_path).unwrap();
+        let archive = Archive::open(&archive_path).unwrap();
 
         // Calculate key as reading code does
         if let Some(file_info) = archive.find_file(filename).unwrap() {

--- a/file-formats/archives/wow-mpq/tests/integration/path_separator_handling.rs
+++ b/file-formats/archives/wow-mpq/tests/integration/path_separator_handling.rs
@@ -23,7 +23,7 @@ fn test_path_normalization_in_archive() {
         .unwrap();
 
     // Open archive and verify all files can be found
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
 
     // All these lookups should work regardless of separator used
     assert!(archive.read_file("dir/subdir/file1.txt").is_ok());
@@ -57,7 +57,7 @@ fn test_listfile_path_separators() {
         .unwrap();
 
     // Open and list files
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let entries = archive.list().unwrap();
 
     // Should have 5 files (4 added + listfile)
@@ -91,7 +91,7 @@ fn test_extraction_path_conversion() {
         .unwrap();
 
     // Extract file
-    let mut archive = Archive::open(&archive_path).unwrap();
+    let archive = Archive::open(&archive_path).unwrap();
     let file_data = archive.read_file("data/config/settings.ini").unwrap();
 
     // When extracting with preserved paths, system separators should be used

--- a/file-formats/archives/wow-mpq/tests/scenarios/real_world/collision_edge_cases.rs
+++ b/file-formats/archives/wow-mpq/tests/scenarios/real_world/collision_edge_cases.rs
@@ -34,7 +34,7 @@ fn test_collision_edge_cases() {
     builder.build(path).unwrap();
 
     // Verify all files maintain integrity
-    let mut archive = Archive::open(path).unwrap();
+    let archive = Archive::open(path).unwrap();
     for (i, filename) in collision_files.iter().enumerate() {
         let data = archive.read_file(filename).unwrap();
         assert_eq!(data.len(), 1024, "File {filename} has wrong size");

--- a/file-formats/archives/wow-mpq/tests/scenarios/real_world/het_bet_creation.rs
+++ b/file-formats/archives/wow-mpq/tests/scenarios/real_world/het_bet_creation.rs
@@ -24,7 +24,7 @@ fn test_het_bet_table_creation() {
         .expect("Failed to create archive");
 
     // Open the archive and verify files can be read
-    let mut archive = Archive::open(&archive_path).expect("Failed to open archive");
+    let archive = Archive::open(&archive_path).expect("Failed to open archive");
 
     // Verify header has HET/BET table positions
     assert_eq!(
@@ -67,7 +67,7 @@ fn test_het_bet_with_compression() {
         .expect("Failed to create archive");
 
     // Open the archive and verify file can be read
-    let mut archive = Archive::open(&archive_path).expect("Failed to open archive");
+    let archive = Archive::open(&archive_path).expect("Failed to open archive");
 
     let data = archive
         .read_file("compressed_file.txt")
@@ -94,7 +94,7 @@ fn test_het_bet_with_many_files() {
         .expect("Failed to create archive");
 
     // Open the archive and verify a few files
-    let mut archive = Archive::open(&archive_path).expect("Failed to open archive");
+    let archive = Archive::open(&archive_path).expect("Failed to open archive");
 
     // Check first, middle, and last files
     for i in [0, 25, 49] {

--- a/file-formats/archives/wow-mpq/tests/thread_safety.rs
+++ b/file-formats/archives/wow-mpq/tests/thread_safety.rs
@@ -28,7 +28,7 @@ fn test_concurrent_archive_opening() {
         .map(|i| {
             let path = archive_path.clone();
             thread::spawn(move || {
-                let mut archive = Archive::open(&path).unwrap();
+                let archive = Archive::open(&path).unwrap();
                 let data = archive.read_file("file_005.txt").unwrap();
                 let content = String::from_utf8(data).unwrap();
                 assert!(content.contains("File 5 content"));
@@ -233,7 +233,7 @@ fn test_custom_processor_thread_safety() {
         .collect();
 
     // Use a custom processor that does multiple operations
-    let results = parallel::process_archives_parallel(&archives, |mut archive| {
+    let results = parallel::process_archives_parallel(&archives, |archive| {
         let mut total_size = 0u64;
         let files = archive.list()?;
 

--- a/warcraft-rs/src/commands/mpq.rs
+++ b/warcraft-rs/src/commands/mpq.rs
@@ -502,7 +502,7 @@ fn list_archive(
     use wow_mpq::database::Database;
 
     let spinner = create_spinner("Opening archive...");
-    let mut archive = Archive::open(path).context("Failed to open archive")?;
+    let archive = Archive::open(path).context("Failed to open archive")?;
     spinner.finish_and_clear();
 
     // Open database if needed
@@ -632,7 +632,7 @@ fn extract_files_with_options(options: ExtractOptions) -> Result<()> {
         let files_to_extract: Vec<String> = if files.is_empty() {
             // For bulk extraction, read listfile directly to avoid slow database lookups
             println!("Reading file list from archive...");
-            let mut archive = Archive::open(&archive_path).context("Failed to open archive")?;
+            let archive = Archive::open(&archive_path).context("Failed to open archive")?;
 
             // Try to read (listfile) directly for faster bulk operations
             let mut file_list = match archive.read_file("(listfile)") {
@@ -2009,7 +2009,7 @@ fn execute_db_command(command: DbCommands) -> Result<()> {
             include_anonymous,
         } => {
             let db = Database::open_default().context("Failed to open database")?;
-            let mut mpq = Archive::open(&archive).context("Failed to open archive")?;
+            let mpq = Archive::open(&archive).context("Failed to open archive")?;
 
             let spinner = create_spinner("Analyzing archive...");
 

--- a/warcraft-rs/tests/integration_extraction.rs
+++ b/warcraft-rs/tests/integration_extraction.rs
@@ -112,7 +112,7 @@ fn test_individual_file_extraction() -> Result<()> {
     );
 
     // Open the archive and get a list of files
-    let mut archive = Archive::open(&test_archive.path).with_context(|| {
+    let archive = Archive::open(&test_archive.path).with_context(|| {
         format!(
             "Failed to open test archive: {}",
             test_archive.path.display()
@@ -384,7 +384,7 @@ fn test_error_handling_missing_files() -> Result<()> {
         test_archive.name
     );
 
-    let mut archive = Archive::open(&test_archive.path).with_context(|| {
+    let archive = Archive::open(&test_archive.path).with_context(|| {
         format!(
             "Failed to open test archive: {}",
             test_archive.path.display()
@@ -442,7 +442,7 @@ fn test_data_integrity() -> Result<()> {
 
     println!("Testing data integrity with: {}", test_archive.name);
 
-    let mut archive = Archive::open(&test_archive.path).with_context(|| {
+    let archive = Archive::open(&test_archive.path).with_context(|| {
         format!(
             "Failed to open test archive: {}",
             test_archive.path.display()
@@ -520,7 +520,7 @@ fn test_batch_extraction(
     max_files: usize,
     preserve_paths: bool,
 ) -> Result<ExtractionTestResult> {
-    let mut archive = Archive::open(archive_path)
+    let archive = Archive::open(archive_path)
         .with_context(|| format!("Failed to open archive: {}", archive_path.display()))?;
 
     let file_list = archive.list().context("Failed to list archive files")?;


### PR DESCRIPTION
Move Archive to store a `File` instead of a `BufReader<File>` and create `BufReader` instances on demand inside methods. This relaxes method receivers from `&mut self` to `&self` where possible (e.g., read_file, list), which enables sharing an Archive across threads and reading multiple files concurrently from the same archive. Updated benches, examples, and tests accordingly.

No breaking changes. Method receivers changed from `&mut self` to `&self` are source compatible; existing code using `&mut` self can still call these methods.