### PR TITLE
m2: M2Parse trait and M2Vec struct

### DIFF
--- a/file-formats/graphics/wow-m2/src/chunks/attachment.rs
+++ b/file-formats/graphics/wow-m2/src/chunks/attachment.rs
@@ -1,8 +1,8 @@
 use crate::io_ext::{ReadExt, WriteExt};
-use std::io::{Read, Write};
+use std::io::{Read, Seek, Write};
 
 use crate::chunks::animation::{M2AnimationBlock, M2AnimationTrack};
-use crate::common::{C3Vector, M2Array};
+use crate::common::C3Vector;
 use crate::error::Result;
 use crate::version::M2Version;
 
@@ -86,7 +86,7 @@ pub struct M2Attachment {
 
 impl M2Attachment {
     /// Parse an attachment from a reader based on the M2 version
-    pub fn parse<R: Read>(reader: &mut R, _version: u32) -> Result<Self> {
+    pub fn parse<R: Read + Seek>(reader: &mut R, _version: u32) -> Result<Self> {
         let id = reader.read_u32_le()?;
         let bone_index = reader.read_u16_le()?;
         let parent_bone_flying = reader.read_u16_le()?;
@@ -145,12 +145,7 @@ impl M2Attachment {
                 y: 0.0,
                 z: 0.0,
             },
-            scale_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
+            scale_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
         }
     }
 }

--- a/file-formats/graphics/wow-m2/src/chunks/camera.rs
+++ b/file-formats/graphics/wow-m2/src/chunks/camera.rs
@@ -1,8 +1,8 @@
 use crate::io_ext::{ReadExt, WriteExt};
-use std::io::{Read, Write};
+use std::io::{Read, Seek, Write};
 
 use crate::chunks::animation::{M2AnimationBlock, M2AnimationTrack};
-use crate::common::{C3Vector, M2Array};
+use crate::common::C3Vector;
 use crate::error::Result;
 use crate::version::M2Version;
 
@@ -44,7 +44,7 @@ pub struct M2Camera {
 
 impl M2Camera {
     /// Parse a camera from a reader based on the M2 version
-    pub fn parse<R: Read>(reader: &mut R, _version: u32) -> Result<Self> {
+    pub fn parse<R: Read + Seek>(reader: &mut R, _version: u32) -> Result<Self> {
         let camera_type = reader.read_u32_le()?;
         let fov = reader.read_f32_le()?;
         let far_clip = reader.read_f32_le()?;
@@ -105,24 +105,9 @@ impl M2Camera {
             fov: 0.8726646, // 50 degrees in radians
             far_clip: 100.0,
             near_clip: 0.1,
-            position_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            target_position_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            roll_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
+            position_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            target_position_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            roll_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
             id,
             flags: M2CameraFlags::empty(),
         }

--- a/file-formats/graphics/wow-m2/src/chunks/light.rs
+++ b/file-formats/graphics/wow-m2/src/chunks/light.rs
@@ -1,9 +1,9 @@
 use crate::io_ext::{ReadExt, WriteExt};
-use std::io::{Read, Write};
+use std::io::{Read, Seek, Write};
 
 use crate::chunks::animation::{M2AnimationBlock, M2AnimationTrack};
 use crate::chunks::color_animation::M2Color;
-use crate::common::{C3Vector, M2Array};
+use crate::common::C3Vector;
 use crate::error::Result;
 use crate::version::M2Version;
 
@@ -71,7 +71,7 @@ pub struct M2Light {
 
 impl M2Light {
     /// Parse a light from a reader based on the M2 version
-    pub fn parse<R: Read>(reader: &mut R, _version: u32) -> Result<Self> {
+    pub fn parse<R: Read + Seek>(reader: &mut R, _version: u32) -> Result<Self> {
         let light_type_raw = reader.read_u8()?;
         let light_type = M2LightType::from_u8(light_type_raw).unwrap_or(M2LightType::Point);
 
@@ -144,36 +144,11 @@ impl M2Light {
                 y: 0.0,
                 z: 0.0,
             },
-            ambient_color_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            diffuse_color_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            attenuation_start_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            attenuation_end_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            visibility_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
+            ambient_color_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            diffuse_color_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            attenuation_start_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            attenuation_end_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            visibility_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
             id,
             flags: match light_type {
                 M2LightType::Directional => M2LightFlags::DIRECTIONAL,

--- a/file-formats/graphics/wow-m2/src/chunks/particle_emitter.rs
+++ b/file-formats/graphics/wow-m2/src/chunks/particle_emitter.rs
@@ -1,5 +1,5 @@
 use crate::io_ext::{ReadExt, WriteExt};
-use std::io::{Read, Write};
+use std::io::{Read, Seek, Write};
 
 use crate::chunks::animation::M2AnimationBlock;
 use crate::chunks::color_animation::M2Color;
@@ -258,7 +258,7 @@ pub struct M2ParticleEmitter {
 
 impl M2ParticleEmitter {
     /// Parse a particle emitter from a reader based on the M2 version
-    pub fn parse<R: Read>(reader: &mut R, version: u32) -> Result<Self> {
+    pub fn parse<R: Read + Seek>(reader: &mut R, version: u32) -> Result<Self> {
         let id = reader.read_u32_le()?;
         let flags = M2ParticleFlags::from_bits_retain(reader.read_u32_le()?);
         let position = C3Vector::parse(reader)?;

--- a/file-formats/graphics/wow-m2/src/chunks/rendering_enhancements.rs
+++ b/file-formats/graphics/wow-m2/src/chunks/rendering_enhancements.rs
@@ -4,23 +4,18 @@
 //! Legion and later expansions, including extended particle systems, waterfall
 //! effects, edge fading, model alpha calculations, and lighting details.
 
-use crate::chunks::animation::{M2AnimationBlock, M2AnimationTrack, M2InterpolationType};
+use crate::chunks::animation::{M2AnimationBlock, M2AnimationTrack};
 use crate::chunks::infrastructure::ChunkReader;
 use crate::chunks::particle_emitter::M2ParticleEmitter;
 use crate::chunks::texture_animation::M2TextureAnimation;
-use crate::common::M2Array;
+use crate::common::M2Parse;
 use crate::error::Result;
 use crate::io_ext::{ReadExt, WriteExt};
-use std::io::{Read, Write};
+use std::io::{Read, Seek, Write};
 
 /// Helper function to create empty animation blocks for compatibility
-fn create_empty_animation_block<T>() -> M2AnimationBlock<T> {
-    let track = M2AnimationTrack {
-        interpolation_type: M2InterpolationType::None,
-        global_sequence: -1,
-        timestamps: M2Array::new(0, 0),
-        values: M2Array::new(0, 0),
-    };
+fn create_empty_animation_block<T: M2Parse>() -> M2AnimationBlock<T> {
+    let track = M2AnimationTrack::default();
     M2AnimationBlock::new(track)
 }
 
@@ -879,7 +874,7 @@ pub struct ExtendedTextureAnimation {
 
 impl ExtendedTextureAnimation {
     /// Parse extended texture animation
-    pub fn parse<R: Read>(reader: &mut R) -> Result<Self> {
+    pub fn parse<R: Read + Seek>(reader: &mut R) -> Result<Self> {
         // Parse base texture animation first
         let base_animation = M2TextureAnimation::parse(reader)?;
 
@@ -1777,6 +1772,8 @@ mod tests {
             // Each animation block: interpolation_type, global_sequence, timestamps, values
             data.extend_from_slice(&0u16.to_le_bytes()); // Interpolation type
             data.extend_from_slice(&(-1i16).to_le_bytes()); // Global sequence
+            data.extend_from_slice(&0u32.to_le_bytes()); // Interpolation ranges count
+            data.extend_from_slice(&0u32.to_le_bytes()); // Interpolation ranges offset
             data.extend_from_slice(&0u32.to_le_bytes()); // Timestamps count
             data.extend_from_slice(&0u32.to_le_bytes()); // Timestamps offset
             data.extend_from_slice(&0u32.to_le_bytes()); // Values count

--- a/file-formats/graphics/wow-m2/src/chunks/ribbon_emitter.rs
+++ b/file-formats/graphics/wow-m2/src/chunks/ribbon_emitter.rs
@@ -1,5 +1,5 @@
 use crate::io_ext::{ReadExt, WriteExt};
-use std::io::{Read, Write};
+use std::io::{Read, Seek, Write};
 
 use crate::chunks::animation::M2AnimationBlock;
 use crate::chunks::color_animation::M2Color;
@@ -48,7 +48,7 @@ pub struct M2RibbonEmitter {
 
 impl M2RibbonEmitter {
     /// Parse a ribbon emitter from a reader based on the M2 version
-    pub fn parse<R: Read>(reader: &mut R, version: u32) -> Result<Self> {
+    pub fn parse<R: Read + Seek>(reader: &mut R, version: u32) -> Result<Self> {
         let bone_index = reader.read_u32_le()?;
         let position = C3Vector::parse(reader)?;
         let texture_indices = M2Array::parse(reader)?;
@@ -209,30 +209,10 @@ mod tests {
             },
             texture_indices: M2Array::new(1, 0x100),
             material_indices: M2Array::new(1, 0x200),
-            color_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            alpha_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            height_above_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            height_below_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
+            color_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            alpha_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            height_above_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            height_below_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
             edges_per_second: 30.0,
             edge_lifetime: 1.0,
             gravity: 9.8,
@@ -285,30 +265,10 @@ mod tests {
             },
             texture_indices: M2Array::new(1, 0x100),
             material_indices: M2Array::new(1, 0x200),
-            color_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            alpha_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            height_above_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            height_below_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
+            color_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            alpha_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            height_above_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            height_below_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
             edges_per_second: 30.0,
             edge_lifetime: 1.0,
             gravity: 9.8,
@@ -362,30 +322,10 @@ mod tests {
             },
             texture_indices: M2Array::new(1, 0x100),
             material_indices: M2Array::new(1, 0x200),
-            color_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            alpha_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            height_above_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            height_below_animation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
+            color_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            alpha_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            height_above_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            height_below_animation: M2AnimationBlock::new(M2AnimationTrack::default()),
             edges_per_second: 30.0,
             edge_lifetime: 1.0,
             gravity: 9.8,

--- a/file-formats/graphics/wow-m2/src/chunks/texture_animation.rs
+++ b/file-formats/graphics/wow-m2/src/chunks/texture_animation.rs
@@ -1,8 +1,7 @@
 use crate::io_ext::{ReadExt, WriteExt};
-use std::io::{Read, Write};
+use std::io::{Read, Seek, Write};
 
 use crate::chunks::animation::{M2AnimationBlock, M2AnimationTrack};
-use crate::common::M2Array;
 use crate::error::Result;
 use crate::version::M2Version;
 
@@ -54,7 +53,7 @@ pub struct M2TextureAnimation {
 
 impl M2TextureAnimation {
     /// Parse a texture animation from a reader
-    pub fn parse<R: Read>(reader: &mut R) -> Result<Self> {
+    pub fn parse<R: Read + Seek>(reader: &mut R) -> Result<Self> {
         let type_raw = reader.read_u16_le()?;
         let animation_type =
             M2TextureAnimationType::from_u16(type_raw).unwrap_or(M2TextureAnimationType::None);
@@ -103,36 +102,11 @@ impl M2TextureAnimation {
     pub fn new(animation_type: M2TextureAnimationType) -> Self {
         Self {
             animation_type,
-            translation_u: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            translation_v: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            rotation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            scale_u: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            scale_v: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
+            translation_u: M2AnimationBlock::new(M2AnimationTrack::default()),
+            translation_v: M2AnimationBlock::new(M2AnimationTrack::default()),
+            rotation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            scale_u: M2AnimationBlock::new(M2AnimationTrack::default()),
+            scale_v: M2AnimationBlock::new(M2AnimationTrack::default()),
         }
     }
 }
@@ -155,6 +129,8 @@ mod tests {
         // Translation U animation track
         data.extend_from_slice(&1u16.to_le_bytes()); // Interpolation type (Linear)
         data.extend_from_slice(&(-1i16).to_le_bytes()); // Global sequence
+        data.extend_from_slice(&0u32.to_le_bytes()); // Interpolation ranges count
+        data.extend_from_slice(&0u32.to_le_bytes()); // Interpolation ranges offset
         data.extend_from_slice(&0u32.to_le_bytes()); // Timestamps count
         data.extend_from_slice(&0u32.to_le_bytes()); // Timestamps offset
         data.extend_from_slice(&0u32.to_le_bytes()); // Values count
@@ -163,6 +139,8 @@ mod tests {
         // Translation V animation track
         data.extend_from_slice(&1u16.to_le_bytes()); // Interpolation type (Linear)
         data.extend_from_slice(&(-1i16).to_le_bytes()); // Global sequence
+        data.extend_from_slice(&0u32.to_le_bytes()); // Interpolation ranges count
+        data.extend_from_slice(&0u32.to_le_bytes()); // Interpolation ranges offset
         data.extend_from_slice(&0u32.to_le_bytes()); // Timestamps count
         data.extend_from_slice(&0u32.to_le_bytes()); // Timestamps offset
         data.extend_from_slice(&0u32.to_le_bytes()); // Values count
@@ -171,6 +149,8 @@ mod tests {
         // Rotation animation track
         data.extend_from_slice(&1u16.to_le_bytes()); // Interpolation type (Linear)
         data.extend_from_slice(&(-1i16).to_le_bytes()); // Global sequence
+        data.extend_from_slice(&0u32.to_le_bytes()); // Interpolation ranges count
+        data.extend_from_slice(&0u32.to_le_bytes()); // Interpolation ranges offset
         data.extend_from_slice(&0u32.to_le_bytes()); // Timestamps count
         data.extend_from_slice(&0u32.to_le_bytes()); // Timestamps offset
         data.extend_from_slice(&0u32.to_le_bytes()); // Values count
@@ -179,6 +159,8 @@ mod tests {
         // Scale U animation track
         data.extend_from_slice(&1u16.to_le_bytes()); // Interpolation type (Linear)
         data.extend_from_slice(&(-1i16).to_le_bytes()); // Global sequence
+        data.extend_from_slice(&0u32.to_le_bytes()); // Interpolation ranges count
+        data.extend_from_slice(&0u32.to_le_bytes()); // Interpolation ranges offset
         data.extend_from_slice(&0u32.to_le_bytes()); // Timestamps count
         data.extend_from_slice(&0u32.to_le_bytes()); // Timestamps offset
         data.extend_from_slice(&0u32.to_le_bytes()); // Values count
@@ -187,6 +169,8 @@ mod tests {
         // Scale V animation track
         data.extend_from_slice(&1u16.to_le_bytes()); // Interpolation type (Linear)
         data.extend_from_slice(&(-1i16).to_le_bytes()); // Global sequence
+        data.extend_from_slice(&0u32.to_le_bytes()); // Interpolation ranges count
+        data.extend_from_slice(&0u32.to_le_bytes()); // Interpolation ranges offset
         data.extend_from_slice(&0u32.to_le_bytes()); // Timestamps count
         data.extend_from_slice(&0u32.to_le_bytes()); // Timestamps offset
         data.extend_from_slice(&0u32.to_le_bytes()); // Values count

--- a/file-formats/graphics/wow-m2/src/chunks/texture_transform.rs
+++ b/file-formats/graphics/wow-m2/src/chunks/texture_transform.rs
@@ -1,8 +1,8 @@
 use crate::io_ext::{ReadExt, WriteExt};
-use std::io::{Read, Write};
+use std::io::{Read, Seek, Write};
 
 use crate::chunks::animation::{M2AnimationBlock, M2AnimationTrack};
-use crate::common::{C3Vector, M2Array};
+use crate::common::{C3Vector, M2Parse};
 use crate::error::Result;
 use crate::version::M2Version;
 
@@ -60,6 +60,16 @@ pub struct C4Quaternion {
     pub w: f32,
 }
 
+impl M2Parse for C4Quaternion {
+    fn parse<R: Read + Seek>(reader: &mut R) -> Result<Self> {
+        C4Quaternion::parse(reader)
+    }
+
+    fn write<W: Write>(&self, writer: &mut W) -> Result<()> {
+        self.write(writer)
+    }
+}
+
 impl C4Quaternion {
     /// Parse a quaternion from a reader
     pub fn parse<R: Read>(reader: &mut R) -> Result<Self> {
@@ -84,7 +94,7 @@ impl C4Quaternion {
 
 impl M2TextureTransform {
     /// Parse a texture transform from a reader
-    pub fn parse<R: Read>(reader: &mut R) -> Result<Self> {
+    pub fn parse<R: Read + Seek>(reader: &mut R) -> Result<Self> {
         let id = reader.read_u32_le()?;
 
         let transform_type_raw = reader.read_u16_le()?;
@@ -133,24 +143,9 @@ impl M2TextureTransform {
         Self {
             id,
             transform_type,
-            translation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            rotation: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-            scaling: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
+            translation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            rotation: M2AnimationBlock::new(M2AnimationTrack::default()),
+            scaling: M2AnimationBlock::new(M2AnimationTrack::default()),
         }
     }
 }

--- a/file-formats/graphics/wow-m2/src/chunks/transparency_animation.rs
+++ b/file-formats/graphics/wow-m2/src/chunks/transparency_animation.rs
@@ -1,12 +1,11 @@
-use std::io::{Read, Write};
+use std::io::{Read, Seek, Write};
 
-use crate::chunks::animation::{M2AnimationBlock, M2AnimationTrack};
-use crate::common::M2Array;
+use crate::chunks::animation::M2AnimationBlock;
 use crate::error::Result;
 use crate::version::M2Version;
 
 /// Transparency animation structure
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct M2TransparencyAnimation {
     /// Alpha animation
     pub alpha: M2AnimationBlock<f32>,
@@ -14,7 +13,7 @@ pub struct M2TransparencyAnimation {
 
 impl M2TransparencyAnimation {
     /// Parse a transparency animation from a reader
-    pub fn parse<R: Read>(reader: &mut R) -> Result<Self> {
+    pub fn parse<R: Read + Seek>(reader: &mut R) -> Result<Self> {
         let alpha = M2AnimationBlock::parse(reader)?;
 
         Ok(Self { alpha })
@@ -34,14 +33,7 @@ impl M2TransparencyAnimation {
 
     /// Create a new transparency animation with default values
     pub fn new() -> Self {
-        Self {
-            alpha: M2AnimationBlock::new(M2AnimationTrack {
-                interpolation_type: crate::chunks::animation::M2InterpolationType::None,
-                global_sequence: -1,
-                timestamps: M2Array::new(0, 0),
-                values: M2Array::new(0, 0),
-            }),
-        }
+        Self::default()
     }
 }
 
@@ -57,6 +49,8 @@ mod tests {
         // Alpha animation track
         data.extend_from_slice(&1u16.to_le_bytes()); // Interpolation type (Linear)
         data.extend_from_slice(&(-1i16).to_le_bytes()); // Global sequence
+        data.extend_from_slice(&0u32.to_le_bytes()); // Interpolation ranges count
+        data.extend_from_slice(&0u32.to_le_bytes()); // Interpolation ranges offset
         data.extend_from_slice(&0u32.to_le_bytes()); // Timestamps count
         data.extend_from_slice(&0u32.to_le_bytes()); // Timestamps offset
         data.extend_from_slice(&0u32.to_le_bytes()); // Values count


### PR DESCRIPTION
- M2Parse is used for parsing and writing types in the M2 format.
- M2Vec represents array references and data in M2 files.