### PR TITLE
fix(blp): correct palette size and 4-bit alpha encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Fixed
 
+- **wow-blp**: Fixed BLP1 palette size to use correct 256 colors instead of 255
+- **wow-blp**: Fixed 4-bit alpha encoding formula for RAW1 format conversion
+  - Alpha values now correctly scaled to 0-15 range before packing
 - **wow-blp**: Fixed BLP1 1-bit and 4-bit alpha channel scaling to 8-bit range (PR #46, #32)
   - 1-bit alpha now correctly maps 0→0, 1→255 (was 0→0, 1→1)
   - 4-bit alpha now correctly maps 0-15→0-255 via multiplication by 17 (was 0-15)

--- a/file-formats/graphics/wow-blp/src/convert/error.rs
+++ b/file-formats/graphics/wow-blp/src/convert/error.rs
@@ -32,8 +32,8 @@ pub enum Error {
     /// Color map does not contain exactly 256 entries as required
     #[error("Color map length {0}, 256 expected!")]
     ColorMapLengthInvalid(usize),
-    /// Palette size mismatch (expected 255 colors)
-    #[error("Expected palette of 255 colors, but got {0}")]
+    /// Palette size mismatch (expected 256 colors)
+    #[error("Expected palette of 256 colors, but got {0}")]
     PaletteWrongSize(usize),
     /// Failed to convert decompressed DXT1 data to raw format
     #[error("Failed to process bytes from DXT1 decomporession")]

--- a/file-formats/graphics/wow-blp/src/convert/palette.rs
+++ b/file-formats/graphics/wow-blp/src/convert/palette.rs
@@ -5,7 +5,7 @@ use ::image::RgbaImage;
 pub fn quantize_rgba(
     mut img: RgbaImage,
 ) -> Result<(Vec<u8>, Vec<u32>, color_quant::NeuQuant), Error> {
-    let palette_size = 255; // last color in cmap is not used
+    let palette_size = 256;
     let sample_fact = 10; // speed-quality factor. 1 is best quality, 30 is best perf
 
     // zero alpha values

--- a/file-formats/graphics/wow-blp/src/convert/raw1.rs
+++ b/file-formats/graphics/wow-blp/src/convert/raw1.rs
@@ -136,7 +136,7 @@ pub fn image_to_raw1(
         .into_rgba8();
     let indexed_alpha = index_alpha(&root_image, alpha_bits)?;
     let (root_quantized, cmap, nq) = quantize_rgba(root_image)?;
-    if cmap.len() != 255 {
+    if cmap.len() != 256 {
         return Err(Error::PaletteWrongSize(cmap.len()));
     }
     images.push(Raw1Image {
@@ -194,7 +194,7 @@ fn index_alpha_4bit(image: &RgbaImage) -> Vec<u8> {
                 i += 1;
                 res.push(0);
             }
-            let scaled_alpha = (((pixel[3] as f64) / 255.0) * 123.0) as u8;
+            let scaled_alpha = (((pixel[3] as f64) / 255.0) * 15.0).round() as u8;
             res[i] |= scaled_alpha << bits;
             bits += 4;
         }


### PR DESCRIPTION
# Pull Request

## Summary

Fixes two bugs in the BLP format conversion code for palette-based textures:
1. Palette size was incorrectly set to 255 colors instead of the standard 256
2. 4-bit alpha encoding formula was using wrong scaling factor (123 instead of 15)

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Build system/dependency changes
- [ ] Security fix

## Changes Made

- Fixed palette size from 255 to 256 colors in `palette.rs`
- Fixed 4-bit alpha encoding to correctly scale to 0-15 range before bit packing in `raw1.rs`
- Updated error message to reflect correct expected palette size (256 not 255)

## Testing

### Tested On

- [X] Linux
- [ ] macOS
- [ ] Windows
- [ ] Cross-compilation targets

### WoW Versions Tested

N/A - This is a code correctness fix for encoding/conversion logic

## Quality Assurance

### Code Quality

- [X] Code follows project style guidelines
- [X] Self-review of code completed
- [X] Code is properly documented
- [X] No obvious performance regressions
- [X] Error handling is appropriate

### Required Checks

- [X] `cargo fmt --all` - Code is formatted
- [X] `cargo clippy --all-targets --all-features` - No clippy warnings
- [X] `cargo test --all-features` - All tests pass (16 unit tests + 6 doctests for wow-blp)
- [X] `cargo test --no-default-features` - Tests pass without features
- [X] `cargo deny check` - No security/license issues
- [X] Documentation builds successfully

### Compatibility

- [X] No breaking changes to public API (or properly documented)
- [X] Backward compatibility maintained where possible
- [X] StormLib compatibility preserved (if applicable)
- [X] Cross-platform compatibility verified

## Documentation

- [ ] Updated relevant documentation in `docs/`
- [X] Updated CHANGELOG.md
- [ ] Updated README.md (if applicable)
- [ ] Added/updated code examples
- [ ] Added/updated CLI help text
- [ ] API documentation updated (rustdoc)

## Benchmarks

### Performance Impact

- [X] No performance impact
- [ ] Performance improvement (include metrics)
- [ ] Performance regression (justified and documented)

## Breaking Changes

None - this fixes incorrect behavior.

## Security Considerations

- [X] No security implications
- [ ] Security improvement
- [ ] Potential security impact (reviewed and justified)

## Additional Context

### Dependencies

None - no new dependencies.

### Known Limitations

None identified.

---

## Reviewer Notes

### Areas of Focus

- Verify the palette size change from 255 to 256 is correct for all BLP1 formats
- Confirm the 4-bit alpha scaling formula: `(alpha / 255.0) * 15.0` rounded

---

**By submitting this PR, I confirm that:**

- [X] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] This PR is ready for review (not a draft)
- [X] I am willing to address feedback and make necessary changes
- [X] I understand this may take time to review and merge