### PR TITLE
feat(wow-cdbc): add JSON import support for DBC files

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,19 +2,5 @@
 # Time to wait for a test to complete before timing out
 slow-timeout = { period = "60s", terminate-after = 2 }
 
-# Reuse test binaries across runs for faster execution
-# Useful during development
-reuse-build = true
-
 # Show output of all tests, not just failures
 failure-output = "immediate-final"
-
-[profile.ci]
-# More aggressive timeouts for CI
-slow-timeout = { period = "30s", terminate-after = 3 }
-
-# Always run tests from scratch in CI
-reuse-build = false
-
-# Use all available cores
-test-threads = "num-cpus"

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint-cli2/main/schema/markdownlint-cli2-config-schema.json",
-  // Common directories to ignore (generated/third-party content)
-  "ignores": [".venv/**", "node_modules/**", "vendor/**", "target/**"]
-}

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json",
+  "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint/refs/heads/main/schema/markdownlint-config-schema-strict.json",
   "default": true,
   "MD003": {
     "style": "atx",

--- a/.mise.toml
+++ b/.mise.toml
@@ -3,8 +3,8 @@
 
 [tools]
 # ── Toolchain ──────────────────────────────────
-rust = "1.92"
-node = "22"
+rust = "stable"
+node = "24"
 
 # ── Build tools ────────────────────────────────
 "cargo:cross" = "latest"
@@ -21,7 +21,7 @@ node = "22"
 actionlint = "latest"
 
 # ── Documentation ─────────────────────────────
-mdbook = "latest"
+"cargo:mdbook" = "latest"
 "cargo:mdbook-mermaid" = "latest"
 
 # ── Profiling ─────────────────────────────────

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "aegis"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae1572243695de9c6c8d16c7889899abac907d14c148f1939d837122bbeca79"
+checksum = "78412fa53e6da95324e8902c3641b3ff32ab45258582ea997eb9169c68ffa219"
 dependencies = [
  "cc",
  "softaes",
@@ -64,11 +55,20 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
 ]
 
 [[package]]
@@ -112,9 +112,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -127,44 +127,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -174,9 +174,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -205,14 +205,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "assert_cmd"
-version = "2.0.17"
+name = "as-slice"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
- "doc-comment",
  "libc",
  "predicates",
  "predicates-core",
@@ -227,41 +235,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "av1-grain"
-version = "0.2.4"
+name = "av-scenechange"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3efb2ca85bc610acfa917b5aaa36f3fcbebed5b3182d7f877b02531c4b80c8"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
 dependencies = [
  "anyhow",
  "arrayvec",
  "log",
- "nom",
+ "nom 8.0.0",
  "num-rational",
  "v_frame",
 ]
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8fbc0f831f4519fe8b810b6a7a91410ec83031b8233f730a0480029f6a23f"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -272,9 +285,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bindgen"
@@ -282,7 +295,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -301,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "binrw"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81419ff39e6ed10a92a7f125290859776ced35d9a08a665ae40b23e7ca702f30"
+checksum = "d53195f985e88ab94d1cc87e80049dd2929fd39e4a772c5ae96a7e5c4aad3642"
 dependencies = [
  "array-init",
  "binrw_derive",
@@ -312,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "binrw_derive"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "376404e55ec40d0d6f8b4b7df3f87b87954bd987f0cf9a7207ea3b6ea5c9add4"
+checksum = "5910da05ee556b789032c8ff5a61fb99239580aa3fd0bfaa8f4d094b2aee00ad"
 dependencies = [
  "either",
  "owo-colors",
@@ -346,21 +359,18 @@ checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitstream-io"
-version = "2.6.0"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
+]
 
 [[package]]
 name = "block-buffer"
@@ -382,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -402,16 +412,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.19.0"
+name = "built"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.2"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -447,9 +463,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
 ]
@@ -462,9 +478,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbindgen"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975982cdb7ad6a142be15bdf84aea7ec6a9e5d4d797c004d43185b24cfe4e684"
+checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "clap",
  "heck",
@@ -481,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -497,24 +513,14 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
-]
-
-[[package]]
-name = "cfg-expr"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
-dependencies = [
- "smallvec",
- "target-lexicon",
+ "nom 7.1.3",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_block"
@@ -524,15 +530,15 @@ checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -585,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -595,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -607,18 +613,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.57"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9501bd3f5f09f7bbee01da9a511073ed30a80cd7a509f1214bb74eadea71ad"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -628,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "color_quant"
@@ -640,9 +646,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "concurrent-queue"
@@ -662,20 +668,19 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.1",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
- "unicode-width 0.2.1",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -702,18 +707,18 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -811,9 +816,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -834,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
@@ -863,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2163a0e204a148662b6b6816d4b5d5668a5f2f8df498ccbd5cd0e864e78fecba"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -947,12 +952,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,9 +965,9 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_filter"
-version = "0.1.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -976,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1015,19 +1014,19 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "exr"
-version = "1.73.0"
+version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83197f59927b46c04a183a619b7c29df34e63e63c7869320862268c0ef687e0"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
 dependencies = [
  "bit_field",
  "half",
@@ -1050,17 +1049,23 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "libm",
- "rand 0.9.2",
+ "rand 0.9.4",
  "siphasher",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1079,9 +1084,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1118,6 +1123,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "genawaiter"
 version = "0.99.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,36 +1173,36 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "r-efi 5.3.0",
+ "wasip2",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1190,19 +1219,13 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.13.3"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git2"
@@ -1210,7 +1233,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "libc",
  "libgit2-sys",
  "log",
@@ -1234,12 +1257,13 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1252,6 +1276,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1301,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1325,12 +1355,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1338,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1351,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1365,15 +1396,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1385,15 +1416,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1423,9 +1454,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1433,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.6"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -1443,6 +1474,7 @@ dependencies = [
  "exr",
  "gif",
  "image-webp",
+ "moxcms",
  "num-traits",
  "png",
  "qoi",
@@ -1466,9 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "implode"
@@ -1478,13 +1510,14 @@ checksum = "be6aed12e8500c350a4009ebdcf0098c89948617e9b846e3c9bbc56a48b56914"
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1496,19 +1529,19 @@ dependencies = [
  "console 0.15.11",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.1",
+ "unicode-width 0.2.2",
  "web-time",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console 0.16.2",
+ "console 0.16.3",
  "portable-atomic",
- "unicode-width 0.2.1",
+ "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
 ]
@@ -1544,31 +1577,31 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -1589,29 +1622,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.15"
+name = "itertools"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1624,22 +1666,18 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
-name = "jpeg-decoder"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
-
-[[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1667,27 +1705,27 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lebe"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
 dependencies = [
  "arbitrary",
  "cc",
@@ -1695,9 +1733,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
@@ -1712,30 +1750,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.10.0",
  "libc",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.23"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -1751,31 +1788,30 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loop9"
@@ -1792,7 +1828,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1842,9 +1878,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -1897,14 +1933,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.0.4"
+name = "moxcms"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1914,6 +1949,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,6 +1965,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1937,11 +1990,11 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.1"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1956,26 +2009,25 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -2036,25 +2088,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -2076,15 +2119,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "pack1"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e7cd9bd638dc2c831519a0caa1c006cab771a92b1303403a8322773c5b72d6"
+checksum = "e3b7bb0ecf2e447b1f20ee94ee79ef6eed1e9d4b3c36ce1903b9dea3bf205523"
 dependencies = [
  "bytemuck",
 ]
@@ -2101,9 +2144,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2111,15 +2154,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -2127,6 +2170,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pem-rfc7468"
@@ -2145,9 +2194,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs1"
@@ -2172,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pklib"
@@ -2184,7 +2233,7 @@ checksum = "5a7ff566c5cb263cf6a9f3b8b8ccbeaf236c0b3516c184134c062863258b3789"
 dependencies = [
  "clap",
  "indicatif 0.17.11",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2217,11 +2266,11 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.17.16"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2238,7 +2287,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2256,24 +2305,24 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2295,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "difflib",
@@ -2309,15 +2358,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -2359,27 +2408,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 dependencies = [
  "profiling-procmacros",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
  "syn",
@@ -2387,16 +2436,15 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.7.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
- "lazy_static",
+ "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -2422,11 +2470,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qoi"
@@ -2451,9 +2505,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2465,24 +2519,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2502,7 +2561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2511,16 +2570,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2529,7 +2588,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2543,19 +2602,21 @@ dependencies = [
 
 [[package]]
 name = "rav1e"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
 dependencies = [
+ "aligned-vec",
  "arbitrary",
  "arg_enum_proc_macro",
  "arrayvec",
+ "av-scenechange",
  "av1-grain",
  "bitstream-io",
- "built",
+ "built 0.8.0",
  "cfg-if",
  "interpolate_name",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -2564,23 +2625,21 @@ dependencies = [
  "noop_proc_macro",
  "num-derive",
  "num-traits",
- "once_cell",
  "paste",
  "profiling",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "simd_helpers",
- "system-deps",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "v_frame",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "ravif"
-version = "0.11.20"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5825c26fddd16ab9f515930d49028a630efec172e903483c94796cfe31893e6b"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
 dependencies = [
  "avif-serialize",
  "imgref",
@@ -2593,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2613,11 +2672,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2626,16 +2685,16 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2645,9 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2656,21 +2715,21 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgb"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "roaring"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -2678,9 +2737,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
  "digest",
@@ -2697,12 +2756,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2710,9 +2763,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2729,7 +2782,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2738,14 +2791,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2757,9 +2810,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
  "quick-error 1.2.3",
@@ -2769,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2790,9 +2843,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2826,23 +2879,24 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2902,9 +2956,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_helpers"
@@ -2917,24 +2971,24 @@ dependencies = [
 
 [[package]]
 name = "simsimd"
-version = "6.5.13"
+version = "6.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f81af684ca3dc160907f1478d779bdfd8bae52f55f4c58caba0229670a83a0d"
+checksum = "f4fb3bc3cdce07a7d7d4caa4c54f8aa967f6be41690482b54b24100a2253fa70"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -3018,10 +3072,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "syn"
-version = "2.0.106"
+name = "symlink"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3040,34 +3100,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-deps"
-version = "6.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
-dependencies = [
- "cfg-expr",
- "heck",
- "pkg-config",
- "toml",
- "version-compare",
-]
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
-
-[[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3123,9 +3164,9 @@ dependencies = [
 
 [[package]]
 name = "test-log"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e33b98a582ea0be1168eba097538ee8dd4bbe0f2b01b22ac92ea30054e5be7b"
+checksum = "2f46bf474f0a4afebf92f076d54fd5e63423d9438b8c278a3d2ccb0f47f7cdb3"
 dependencies = [
  "env_logger",
  "test-log-macros",
@@ -3133,14 +3174,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-log-macros"
-version = "0.2.18"
+name = "test-log-core"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
+checksum = "37d4d41320b48bc4a211a9021678fcc0c99569b594ea31c93735b8e517102b4c"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9beb9249a81e430dffd42400a49019bcf548444f1968ff23080a625de0d4d320"
+dependencies = [
+ "syn",
+ "test-log-core",
 ]
 
 [[package]]
@@ -3164,11 +3215,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3184,9 +3235,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3204,13 +3255,16 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.9.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
 dependencies = [
+ "fax",
  "flate2",
- "jpeg-decoder",
+ "half",
+ "quick-error 2.0.1",
  "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -3246,9 +3300,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3266,25 +3320,20 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
- "libc",
- "mio",
  "pin-project-lite",
- "slab",
  "tokio-macros",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3293,50 +3342,48 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -3345,21 +3392,22 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.16",
+ "symlink",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3368,9 +3416,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3389,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3411,7 +3459,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f2fe423c2c954948babb36edda12b737e321d8541d4eae519694f7d512ecab6"
 dependencies = [
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
  "turso_sdk_kit",
@@ -3428,9 +3476,9 @@ dependencies = [
  "aes",
  "aes-gcm",
  "arc-swap",
- "bitflags 2.10.0",
+ "bitflags",
  "branches",
- "built",
+ "built 0.7.7",
  "bumpalo",
  "bytemuck",
  "cfg_block",
@@ -3450,19 +3498,19 @@ dependencies = [
  "parking_lot",
  "paste",
  "polling",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rapidhash",
  "regex",
  "regex-syntax",
  "roaring",
- "rustc-hash 2.1.1",
- "rustix 1.1.3",
+ "rustc-hash 2.1.2",
+ "rustix 1.1.4",
  "ryu",
  "simsimd",
  "strum",
  "strum_macros",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
  "turso_ext",
@@ -3480,7 +3528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2de917b4c5881bfb34ccbb1dcf4992773bc39853eacf248955f2ece7e3cb3049"
 dependencies = [
  "chrono",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "turso_macros",
 ]
 
@@ -3501,12 +3549,12 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ad89caa1c4888756bd027485499d1dc4c8420d15887ab32aa28b707c411221"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "memchr",
  "miette",
  "strum",
  "strum_macros",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "turso_macros",
 ]
 
@@ -3551,7 +3599,7 @@ dependencies = [
  "roaring",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "turso_core",
  "turso_parser",
@@ -3583,14 +3631,14 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -3609,9 +3657,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
@@ -3621,9 +3669,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -3679,11 +3727,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "sha1_smol",
  "wasm-bindgen",
@@ -3711,12 +3759,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version-compare"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"
@@ -3747,6 +3789,7 @@ dependencies = [
 name = "warcraft-rs"
 version = "0.6.4"
 dependencies = [
+ "aegis",
  "anyhow",
  "assert_cmd",
  "chrono",
@@ -3758,8 +3801,9 @@ dependencies = [
  "glob",
  "humansize",
  "image",
- "indicatif 0.18.3",
+ "indicatif 0.18.4",
  "log",
+ "num-bigint-dig",
  "predicates",
  "prettytable-rs",
  "rayon",
@@ -3767,7 +3811,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "turso",
  "wow-adt",
@@ -3787,21 +3831,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.3+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
-dependencies = [
- "wit-bindgen 0.45.0",
-]
-
-[[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3815,35 +3850,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3851,22 +3873,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3899,17 +3921,17 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.10.0",
- "hashbrown",
+ "bitflags",
+ "hashbrown 0.15.5",
  "indexmap",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3927,9 +3949,9 @@ dependencies = [
 
 [[package]]
 name = "weezl"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "which"
@@ -3961,11 +3983,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3976,22 +3998,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4000,20 +4022,14 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -4023,20 +4039,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -4050,15 +4066,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -4068,20 +4075,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4108,28 +4106,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
-dependencies = [
- "windows-link 0.1.3",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -4145,12 +4126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4161,12 +4136,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4181,22 +4150,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4211,12 +4168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4227,12 +4178,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4247,12 +4192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4265,25 +4204,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
+name = "winnow"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"
@@ -4293,6 +4223,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -4343,7 +4279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",
@@ -4385,7 +4321,7 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "wow-mpq",
 ]
 
@@ -4403,7 +4339,7 @@ dependencies = [
  "tempfile",
  "test-log",
  "texpresso",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4424,7 +4360,7 @@ dependencies = [
  "serde_yaml_ng",
  "tempfile",
  "test-case",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4432,7 +4368,7 @@ name = "wow-m2"
 version = "0.6.4"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags",
  "bytes",
  "criterion",
  "env_logger",
@@ -4444,7 +4380,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "test-case",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "wow-blp",
  "wow-mpq",
 ]
@@ -4477,12 +4413,12 @@ dependencies = [
  "predicates",
  "pretty_assertions",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "rsa",
  "sha1",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -4492,7 +4428,7 @@ version = "0.6.4"
 dependencies = [
  "criterion",
  "memchr",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4500,13 +4436,13 @@ name = "wow-wdt"
 version = "0.6.4"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags",
  "criterion",
  "pretty_assertions",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4514,20 +4450,26 @@ name = "wow-wmo"
 version = "0.6.4"
 dependencies = [
  "binrw",
- "bitflags 2.10.0",
+ "bitflags",
  "criterion",
  "tempfile",
  "test-case",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yansi"
@@ -4537,9 +4479,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4548,9 +4490,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4560,18 +4502,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4580,18 +4522,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4601,15 +4543,15 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4618,9 +4560,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4629,9 +4571,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4639,10 +4581,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "zune-core"
-version = "0.4.12"
+name = "zmij"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-inflate"
@@ -4655,9 +4603,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.20"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1f7e205ce79eb2da3cd71c5f55f3589785cb7c79f6a03d1c8d1491bda5d089"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,6 +1114,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,9 +1278,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1282,6 +1286,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1824,11 +1833,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -8,70 +8,75 @@ version = 2
 yanked = "deny"
 # Security advisory exceptions:
 ignore = [
-    # RUSTSEC-2023-0071: RSA timing sidechannel attack vulnerability
-    # Justification: The rsa crate is only used for MPQ archive signature verification (public key operations).
-    # The vulnerability affects private key operations (decryption/signing) which we do not perform.
-    # Public key verification is not vulnerable to timing attacks in the same way.
-    # Dependency tree: rsa -> used for verifying MPQ signatures only
-    # Last reviewed: 2025-02-12
-    "RUSTSEC-2023-0071",
+  # RUSTSEC-2023-0071: RSA timing sidechannel attack vulnerability
+  # Justification: The rsa crate is only used for MPQ archive signature verification (public key operations).
+  # The vulnerability affects private key operations (decryption/signing) which we do not perform.
+  # Public key verification is not vulnerable to timing attacks in the same way.
+  # Dependency tree: rsa -> used for verifying MPQ signatures only
+  # Last reviewed: 2025-02-12
+  "RUSTSEC-2023-0071",
 
-    # RUSTSEC-2024-0436: paste crate is unmaintained
-    # Justification: This is a transitive dependency from rav1e (AV1 encoder), used only when building
-    # the CLI with image encoding features. rav1e is itself maintained and the paste usage is
-    # limited to macro expansion during compilation, not runtime.
-    # Dependency tree: rav1e -> paste (build-time macro only)
-    # Alternative: Consider switching from rav1e when a suitable AV1 encoder alternative is available
-    # Last reviewed: 2025-02-12
-    "RUSTSEC-2024-0436",
+  # RUSTSEC-2024-0436: paste crate is unmaintained
+  # Justification: This is a transitive dependency from rav1e (AV1 encoder), used only when building
+  # the CLI with image encoding features. rav1e is itself maintained and the paste usage is
+  # limited to macro expansion during compilation, not runtime.
+  # Dependency tree: rav1e -> paste (build-time macro only)
+  # Alternative: Consider switching from rav1e when a suitable AV1 encoder alternative is available
+  # Last reviewed: 2025-02-12
+  "RUSTSEC-2024-0436",
 
-    # RUSTSEC-2025-0119: number_prefix crate is unmaintained
-    # Justification: This is a transitive dependency from indicatif (via pklib -> wow-mpq).
-    # The crate provides formatting for numbers with SI unit prefixes. It is used in progress bar
-    # rendering for formatting large byte counts. The functionality is stable and the unmaintained
-    # status does not pose security risks (no vulnerabilities reported).
-    # Dependency tree: number_prefix -> indicatif -> pklib -> wow-mpq
-    # Alternative: Could migrate to indicatif 0.18.x which uses unit-prefix, but this would require
-    # updating pklib which is out of our control.
-    # Last reviewed: 2025-02-16
-    "RUSTSEC-2025-0119",
+  # RUSTSEC-2025-0119: number_prefix crate is unmaintained
+  # Justification: This is a transitive dependency from indicatif (via pklib -> wow-mpq).
+  # The crate provides formatting for numbers with SI unit prefixes. It is used in progress bar
+  # rendering for formatting large byte counts. The functionality is stable and the unmaintained
+  # status does not pose security risks (no vulnerabilities reported).
+  # Dependency tree: number_prefix -> indicatif -> pklib -> wow-mpq
+  # Alternative: Could migrate to indicatif 0.18.x which uses unit-prefix, but this would require
+  # updating pklib which is out of our control.
+  # Last reviewed: 2025-02-16
+  "RUSTSEC-2025-0119",
 ]
 
 [licenses]
 version = 2
 allow = [
-    "MIT",
-    "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
-    "BSD-3-Clause",
-    "BSD-2-Clause",
-    "ISC",
-    "Unicode-3.0",
-    "Unicode-DFS-2016",
-    "CC0-1.0",
-    "MPL-2.0",
-    "Zlib",
-    "bzip2-1.0.6",
-    "NCSA",
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
+  "BSD-2-Clause",
+  "ISC",
+  "Unicode-3.0",
+  "CC0-1.0",
+  "MPL-2.0",
+  "Zlib",
+  "bzip2-1.0.6",
+  "NCSA",
 ]
 
 [bans]
 multiple-versions = "warn"
 deny = []
 skip = [
-    # These duplicates are from external dependencies we can't control
-    { name = "bitflags", version = "1.3.2" },  # Used by png/image
-    { name = "thiserror", version = "1.0" },   # Used by rav1e
-    { name = "thiserror-impl", version = "1.0" },
-    { name = "rand", version = "0.8" },        # Used by rsa
-    { name = "rand_core", version = "0.6" },
-    { name = "rand_chacha", version = "0.3" },
-    { name = "getrandom", version = "0.2" },
-    { name = "unicode-width", version = "0.1" }, # Used by prettytable-rs
-    { name = "windows-sys", version = "0.59" },
-    { name = "windows-targets", version = "0.52" },
-    { name = "windows_x86_64_gnu", version = "0.52" },
-    { name = "windows_x86_64_msvc", version = "0.52" },
+  # These duplicates are from external dependencies we can't control
+  { name = "hashbrown", version = "0.15.5" },
+  { name = "indicatif", version = "0.17.11" },
+  { name = "itertools", version = "0.12.1" },
+  { name = "itertools", version = "0.13.0" },
+  { name = "linux-raw-sys", version = "0.4.15" },
+  { name = "nom", version = "7.1.3" },
+  { name = "r-efi", version = "5.3.0" },
+  { name = "rustc-hash", version = "1.1.0" },
+  { name = "rustix", version = "0.38.44" },
+  { name = "windows-sys", version = "0.48.0" },
+  { name = "windows-sys", version = "0.61.2" },
+  { name = "windows_aarch64_gnullvm", version = "0.48.5" },
+  { name = "windows_aarch64_msvc", version = "0.48.5" },
+  { name = "windows_i686_gnu", version = "0.48.5" },
+  { name = "windows_i686_msvc", version = "0.48.5" },
+  { name = "windows_x86_64_gnullvm", version = "0.48.5" },
+  { name = "winnow", version = "0.7.15" },
+  { name = "wit-bindgen", version = "0.51.0" },
 ]
 
 [sources]

--- a/file-formats/archives/wow-mpq/Cargo.toml
+++ b/file-formats/archives/wow-mpq/Cargo.toml
@@ -46,11 +46,18 @@ rayon = "1.10"
 
 # Thread-safe data structures and caching
 parking_lot = "0.12"
-lru = "0.12"
+lru = "0.18"
 
 
 # Async I/O support (optional)
-tokio = { version = "1.0", features = ["io-util", "time", "sync", "rt", "fs", "macros"], optional = true }
+tokio = { version = "1.0", features = [
+  "io-util",
+  "time",
+  "sync",
+  "rt",
+  "fs",
+  "macros",
+], optional = true }
 
 # Memory-mapped files (optional)
 memmap2 = { version = "0.9", optional = true }

--- a/file-formats/archives/wow-mpq/src/patch_chain.rs
+++ b/file-formats/archives/wow-mpq/src/patch_chain.rs
@@ -175,7 +175,7 @@ impl PatchChain {
     /// 2. Read all patches for this file in priority order
     /// 3. Apply patches sequentially to produce the final result
     fn read_patched_file(&mut self, filename: &str, _patch_idx: usize) -> Result<Vec<u8>> {
-        use crate::patch::{PatchFile, apply_patch};
+        use crate::patch::{apply_patch, PatchFile};
 
         // Step 1: Find the base file (search lower priority archives)
         let mut base_data: Option<Vec<u8>> = None;
@@ -437,7 +437,7 @@ impl PatchChain {
         let mut loaded_archives = loaded_archives?;
 
         // Sort by priority (highest first)
-        loaded_archives.sort_by(|a, b| b.priority.cmp(&a.priority));
+        loaded_archives.sort_by_key(|b| std::cmp::Reverse(b.priority));
 
         let mut chain = Self {
             archives: loaded_archives,

--- a/file-formats/archives/wow-mpq/src/security.rs
+++ b/file-formats/archives/wow-mpq/src/security.rs
@@ -16,8 +16,8 @@
 
 use crate::{Error, Result};
 use std::path::{Component, Path};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 /// Security limits for various MPQ structures
@@ -747,11 +747,9 @@ pub fn validate_decompression_operation(
             "Large decompression: {} -> {} bytes ({}:1 ratio) method=0x{:02X} path={}",
             compressed_size,
             expected_decompressed_size,
-            if compressed_size > 0 {
-                expected_decompressed_size / compressed_size
-            } else {
-                0
-            },
+            expected_decompressed_size
+                .checked_div(compressed_size)
+                .unwrap_or(0),
             compression_method,
             file_path.unwrap_or("<unknown>")
         );
@@ -839,12 +837,10 @@ mod tests {
         );
 
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Invalid MPQ signature")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid MPQ signature"));
     }
 
     #[test]
@@ -865,12 +861,10 @@ mod tests {
         );
 
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Hash table too large")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Hash table too large"));
     }
 
     #[test]
@@ -906,40 +900,34 @@ mod tests {
         let limits = SecurityLimits::default();
 
         // Valid file
-        assert!(
-            validate_file_bounds(
-                1000,   // offset
-                2048,   // decompressed size
-                1024,   // compressed size
-                100000, // archive size
-                &limits,
-            )
-            .is_ok()
-        );
+        assert!(validate_file_bounds(
+            1000,   // offset
+            2048,   // decompressed size
+            1024,   // compressed size
+            100000, // archive size
+            &limits,
+        )
+        .is_ok());
 
         // File extends beyond archive
-        assert!(
-            validate_file_bounds(
-                99000,  // offset
-                2048,   // decompressed size
-                2000,   // compressed size (would end at 101000)
-                100000, // archive size
-                &limits,
-            )
-            .is_err()
-        );
+        assert!(validate_file_bounds(
+            99000,  // offset
+            2048,   // decompressed size
+            2000,   // compressed size (would end at 101000)
+            100000, // archive size
+            &limits,
+        )
+        .is_err());
 
         // Potential zip bomb
-        assert!(
-            validate_file_bounds(
-                1000,    // offset
-                1000000, // decompressed size (1MB)
-                100,     // compressed size (100 bytes = 10000:1 ratio)
-                100000,  // archive size
-                &limits,
-            )
-            .is_err()
-        );
+        assert!(validate_file_bounds(
+            1000,    // offset
+            1000000, // decompressed size (1MB)
+            100,     // compressed size (100 bytes = 10000:1 ratio)
+            100000,  // archive size
+            &limits,
+        )
+        .is_err());
     }
 
     #[test]
@@ -959,15 +947,13 @@ mod tests {
     #[test]
     fn test_sector_validation() {
         // Valid sector
-        assert!(
-            validate_sector_data(
-                0,    // sector index
-                4096, // sector size
-                2048, // data size
-                None, // no CRC check
-            )
-            .is_ok()
-        );
+        assert!(validate_sector_data(
+            0,    // sector index
+            4096, // sector size
+            2048, // data size
+            None, // no CRC check
+        )
+        .is_ok());
 
         // Invalid sector size
         assert!(validate_sector_data(0, 0, 1024, None).is_err());
@@ -1054,40 +1040,44 @@ mod tests {
         let limits = SecurityLimits::default();
 
         // Normal compression should pass
-        assert!(
-            detect_compression_bomb_patterns(1024, 10240, 0x02, Some("data/file.txt"), &limits)
-                .is_ok()
-        );
+        assert!(detect_compression_bomb_patterns(
+            1024,
+            10240,
+            0x02,
+            Some("data/file.txt"),
+            &limits
+        )
+        .is_ok());
 
         // Extreme ratio should fail
-        assert!(
-            detect_compression_bomb_patterns(
-                100,
-                100_000_000,
-                0x02,
-                Some("data/file.txt"),
-                &limits
-            )
-            .is_err()
-        );
+        assert!(detect_compression_bomb_patterns(
+            100,
+            100_000_000,
+            0x02,
+            Some("data/file.txt"),
+            &limits
+        )
+        .is_err());
 
         // Tiny compressed with huge output should fail
-        assert!(
-            detect_compression_bomb_patterns(50, 20_000_000, 0x02, Some("data/file.txt"), &limits)
-                .is_err()
-        );
+        assert!(detect_compression_bomb_patterns(
+            50,
+            20_000_000,
+            0x02,
+            Some("data/file.txt"),
+            &limits
+        )
+        .is_err());
 
         // Nested archive with large size should fail
-        assert!(
-            detect_compression_bomb_patterns(
-                1_000_000,
-                100_000_000,
-                0x02,
-                Some("nested.mpq"),
-                &limits
-            )
-            .is_err()
-        );
+        assert!(detect_compression_bomb_patterns(
+            1_000_000,
+            100_000_000,
+            0x02,
+            Some("nested.mpq"),
+            &limits
+        )
+        .is_err());
     }
 
     #[test]

--- a/file-formats/database/wow-cdbc/src/bin/dbd_to_yaml.rs
+++ b/file-formats/database/wow-cdbc/src/bin/dbd_to_yaml.rs
@@ -3,13 +3,22 @@ use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(name = "dbd_to_yaml")]
-#[command(about = "Convert DBD (Database Definition) files to YAML schema format")]
+#[command(about = "Convert a DBD (Database Definition) file to a YAML schema for a specific WoW build version")]
+#[command(long_about = "Reads a WoWDBDefs .dbd file and outputs a YAML schema that is \
+    compatible with the wow-cdbc schema loader. Use --build to target a specific \
+    game version (e.g. '3.3.5.12340'). If --build is omitted the first build \
+    section in the DBD is used.")]
 struct Cli {
     /// The DBD file to convert
     input: PathBuf,
 
     /// Output YAML file
     output: PathBuf,
+
+    /// Target build version string (e.g. '3.3.5.12340' or '1.12.1.5875').
+    /// Must match a version listed in the DBD file.
+    #[arg(short, long)]
+    build: Option<String>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -17,64 +26,50 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cli = Cli::parse();
 
-    println!("Converting DBD file: {}", cli.input.display());
-
-    // Parse DBD using the provided function
-    let dbd_definition = wow_cdbc::dbd::parse_dbd_file(&cli.input)?;
-
-    println!("Columns: {}", dbd_definition.columns.len());
-    println!("Builds: {}", dbd_definition.builds.len());
-    println!("Layouts: {}", dbd_definition.layouts.len());
-
-    // Convert to YAML schema format
-    let mut schema = serde_yaml_ng::Mapping::new();
-
-    // Extract name from filename
-    let name = cli
+    let base_name = cli
         .input
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("Unknown")
         .to_string();
 
-    schema.insert(
-        serde_yaml_ng::Value::String("name".to_string()),
-        serde_yaml_ng::Value::String(name),
-    );
+    let dbd_file = wow_cdbc::dbd::parse_dbd_file(&cli.input)?;
 
-    let mut fields = serde_yaml_ng::Sequence::new();
+    let build_filter = cli.build.as_deref();
+    let generate_all = build_filter.is_none();
 
-    for column in &dbd_definition.columns {
-        let mut field = serde_yaml_ng::Mapping::new();
-        field.insert(
-            serde_yaml_ng::Value::String("name".to_string()),
-            serde_yaml_ng::Value::String(column.name.clone()),
-        );
-        field.insert(
-            serde_yaml_ng::Value::String("type".to_string()),
-            serde_yaml_ng::Value::String(column.base_type.clone()),
-        );
+    let schemas = wow_cdbc::dbd::convert_to_yaml_schemas(&dbd_file, &base_name, build_filter, generate_all);
 
-        if let Some(ref comment) = column.comment {
-            field.insert(
-                serde_yaml_ng::Value::String("comment".to_string()),
-                serde_yaml_ng::Value::String(comment.to_string()),
-            );
+    if schemas.is_empty() {
+        if let Some(b) = build_filter {
+            eprintln!("No build section matched '{}' in {}", b, cli.input.display());
+            eprintln!("Available builds:");
+            for build in &dbd_file.builds {
+                eprintln!("  {}", build.versions.join(", "));
+            }
+            std::process::exit(1);
+        } else {
+            eprintln!("No build sections found in {}", cli.input.display());
+            std::process::exit(1);
         }
-
-        fields.push(serde_yaml_ng::Value::Mapping(field));
     }
 
-    schema.insert(
-        serde_yaml_ng::Value::String("fields".to_string()),
-        serde_yaml_ng::Value::Sequence(fields),
-    );
+    // When a build filter is given, write the single matching schema to the requested output path.
+    // When no filter is given and there are multiple schemas, write only the first one
+    // (since the user provided a single output path).
+    let (_, yaml_content, version_suffix) = &schemas[0];
 
-    // Write YAML
-    let yaml_content = serde_yaml_ng::to_string(&serde_yaml_ng::Value::Mapping(schema))?;
+    if schemas.len() > 1 && build_filter.is_none() {
+        eprintln!(
+            "Note: DBD has {} build sections. Writing schema for '{}'. \
+            Use --build to select a specific version.",
+            schemas.len(),
+            version_suffix
+        );
+    }
+
     std::fs::write(&cli.output, yaml_content)?;
-
-    println!("Converted to YAML: {}", cli.output.display());
+    println!("Schema for '{}' written to: {}", version_suffix, cli.output.display());
 
     Ok(())
 }

--- a/file-formats/database/wow-cdbc/src/bin/dbd_to_yaml.rs
+++ b/file-formats/database/wow-cdbc/src/bin/dbd_to_yaml.rs
@@ -3,11 +3,15 @@ use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(name = "dbd_to_yaml")]
-#[command(about = "Convert a DBD (Database Definition) file to a YAML schema for a specific WoW build version")]
-#[command(long_about = "Reads a WoWDBDefs .dbd file and outputs a YAML schema that is \
+#[command(
+    about = "Convert a DBD (Database Definition) file to a YAML schema for a specific WoW build version"
+)]
+#[command(
+    long_about = "Reads a WoWDBDefs .dbd file and outputs a YAML schema that is \
     compatible with the wow-cdbc schema loader. Use --build to target a specific \
     game version (e.g. '3.3.5.12340'). If --build is omitted the first build \
-    section in the DBD is used.")]
+    section in the DBD is used."
+)]
 struct Cli {
     /// The DBD file to convert
     input: PathBuf,
@@ -38,11 +42,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let build_filter = cli.build.as_deref();
     let generate_all = build_filter.is_none();
 
-    let schemas = wow_cdbc::dbd::convert_to_yaml_schemas(&dbd_file, &base_name, build_filter, generate_all);
+    let schemas =
+        wow_cdbc::dbd::convert_to_yaml_schemas(&dbd_file, &base_name, build_filter, generate_all);
 
     if schemas.is_empty() {
         if let Some(b) = build_filter {
-            eprintln!("No build section matched '{}' in {}", b, cli.input.display());
+            eprintln!(
+                "No build section matched '{}' in {}",
+                b,
+                cli.input.display()
+            );
             eprintln!("Available builds:");
             for build in &dbd_file.builds {
                 eprintln!("  {}", build.versions.join(", "));
@@ -69,7 +78,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     std::fs::write(&cli.output, yaml_content)?;
-    println!("Schema for '{}' written to: {}", version_suffix, cli.output.display());
+    println!(
+        "Schema for '{}' written to: {}",
+        version_suffix,
+        cli.output.display()
+    );
 
     Ok(())
 }

--- a/file-formats/database/wow-cdbc/src/dbd.rs
+++ b/file-formats/database/wow-cdbc/src/dbd.rs
@@ -537,15 +537,10 @@ fn generate_yaml_schema(
 
     yaml.push_str(&format!("name: {base_name}\n"));
 
-    // Find key field
-    let key_field = build
-        .fields
-        .iter()
-        .find(|f| f.is_key)
-        .map(|f| f.name.clone())
-        .unwrap_or_else(|| "ID".to_string());
-
-    yaml.push_str(&format!("key_field: {key_field}\n"));
+    // Only emit key_field when the DBD explicitly marks one with $id$
+    if let Some(key_field) = build.fields.iter().find(|f| f.is_key).map(|f| &f.name) {
+        yaml.push_str(&format!("key_field: {key_field}\n"));
+    }
     yaml.push_str("fields:\n");
 
     // Generate fields

--- a/file-formats/database/wow-cdbc/src/dbd.rs
+++ b/file-formats/database/wow-cdbc/src/dbd.rs
@@ -124,8 +124,8 @@ pub fn parse_dbd_content(content: &str) -> Result<DbdFile, Box<dyn std::error::E
     for line in content.lines() {
         let line = line.trim();
 
-        // Skip empty lines
-        if line.is_empty() {
+        // Skip empty lines and human-readable COMMENT lines (per DBD spec).
+        if line.is_empty() || line.starts_with("COMMENT") {
             continue;
         }
 
@@ -147,16 +147,21 @@ pub fn parse_dbd_content(content: &str) -> Result<DbdFile, Box<dyn std::error::E
             current_section = Some("COLUMNS");
             continue;
         } else if let Some(stripped) = line.strip_prefix("BUILD ") {
-            // Save previous build if any
-            save_pending_build(
-                &mut builds,
-                &mut current_build_versions,
-                &mut current_build_fields,
-            );
-
-            current_section = Some("BUILD");
             let versions: Vec<String> = stripped.split(", ").map(|s| s.to_string()).collect();
-            current_build_versions = versions;
+            // Stacked BUILD lines (consecutive BUILDs with no fields between them)
+            // share the same following field block. Accumulate versions instead
+            // of starting a new build with an empty body.
+            if current_section == Some("BUILD") && current_build_fields.is_empty() {
+                current_build_versions.extend(versions);
+            } else {
+                save_pending_build(
+                    &mut builds,
+                    &mut current_build_versions,
+                    &mut current_build_fields,
+                );
+                current_build_versions = versions;
+            }
+            current_section = Some("BUILD");
             continue;
         } else if let Some(stripped) = line.strip_prefix("LAYOUT ") {
             // Save previous build/layout if any
@@ -328,6 +333,9 @@ fn parse_field_line(line: &str) -> DbdField {
     let mut is_relation = false;
     let mut is_noninline = false;
 
+    // Strip trailing `// human comment` (per WoWDBDefs DBD spec).
+    let line = line.split("//").next().unwrap_or(line).trim();
+
     // Check for special markers
     let line = if let Some(stripped) = line.strip_prefix("$id$") {
         is_key = true;
@@ -412,7 +420,13 @@ pub fn convert_to_yaml_schemas(
     for build in &dbd_file.builds {
         if should_generate_version(&build.versions, version_filter, generate_all) {
             let version_suffix = determine_version_suffix(&build.versions);
-            let yaml_content = generate_yaml_schema(&column_map, build, base_name, &version_suffix);
+            let yaml_content = generate_yaml_schema(
+                &column_map,
+                build,
+                base_name,
+                &version_suffix,
+                version_filter,
+            );
             let filename = generate_filename(base_name, &build.versions[0]);
             results.push((filename, yaml_content, version_suffix));
         }
@@ -427,8 +441,13 @@ pub fn convert_to_yaml_schemas(
 
         if should_generate_version(&pseudo_build.versions, version_filter, generate_all) {
             let version_suffix = determine_version_suffix(&pseudo_build.versions);
-            let yaml_content =
-                generate_yaml_schema(&column_map, &pseudo_build, base_name, &version_suffix);
+            let yaml_content = generate_yaml_schema(
+                &column_map,
+                &pseudo_build,
+                base_name,
+                &version_suffix,
+                version_filter,
+            );
             let filename = if layout.builds.is_empty() {
                 format!("{}_layout_{}.yaml", base_name, &layout.hash[..8])
             } else {
@@ -450,8 +469,13 @@ pub fn convert_to_yaml_schemas(
             fields: layout.fields.clone(),
         };
         let version_suffix = "Latest".to_string();
-        let yaml_content =
-            generate_yaml_schema(&column_map, &pseudo_build, base_name, &version_suffix);
+        let yaml_content = generate_yaml_schema(
+            &column_map,
+            &pseudo_build,
+            base_name,
+            &version_suffix,
+            version_filter,
+        );
         let filename = format!("{base_name}_latest.yaml");
         results.push((filename, yaml_content, version_suffix));
     }
@@ -522,11 +546,57 @@ fn generate_filename(base_name: &str, version: &str) -> String {
     format!("{base_name}_{sanitized_version}.yaml")
 }
 
+/// Locale ordering for the WotLK-era (3.x and 4.0 pre-collapse) locstring layout.
+/// 16 stringref slots are stored in this order, followed by a single u32 flags field.
+const LOCSTRING_LOCALES_WOTLK: &[&str] = &[
+    "enUS", "koKR", "frFR", "deDE", "zhCN", "zhTW", "esES", "esMX", "ruRU", "unk9", "unk10",
+    "unk11", "unk12", "unk13", "unk14", "unk15",
+];
+
+/// Locale ordering for the Vanilla/TBC-era (1.x, 2.x) locstring layout.
+/// 8 stringref slots are stored in this order, followed by a single u32 flags field.
+const LOCSTRING_LOCALES_CLASSIC: &[&str] = &[
+    "enUS", "koKR", "frFR", "deDE", "zhCN", "zhTW", "esES", "esMX",
+];
+
+/// Determine the per-locale stringref slots that make up a `locstring`.
+///
+/// When `target_version` is provided (e.g. the `--version` CLI filter), the
+/// era is resolved from that string. Otherwise it's resolved from the build's
+/// first listed version. This matters because a single field block in a DBD
+/// is often shared across many builds spanning multiple expansions; the file
+/// on disk only matches one of them, so the user's target wins.
+///
+/// Returns an empty slice for 4.1+ builds where `locstring` collapsed back to
+/// a single string field.
+fn locstring_locales_for_build(
+    build: &DbdBuild,
+    target_version: Option<&str>,
+) -> &'static [&'static str] {
+    let pick = target_version
+        .or_else(|| build.versions.first().map(|s| s.as_str()))
+        .unwrap_or("");
+
+    let mut parts = pick.split('.');
+    let major: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let minor: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+
+    match major {
+        0..=2 => LOCSTRING_LOCALES_CLASSIC,
+        3 => LOCSTRING_LOCALES_WOTLK,
+        // The 4.0 pre-Cataclysm client kept the WotLK locstring layout; from
+        // 4.1 onward it collapsed back to a single string field.
+        4 if minor == 0 => LOCSTRING_LOCALES_WOTLK,
+        _ => &[],
+    }
+}
+
 fn generate_yaml_schema(
     column_map: &HashMap<String, &DbdColumn>,
     build: &DbdBuild,
     base_name: &str,
     version_suffix: &str,
+    target_version: Option<&str>,
 ) -> String {
     let mut yaml = String::new();
 
@@ -543,9 +613,33 @@ fn generate_yaml_schema(
     }
     yaml.push_str("fields:\n");
 
+    let locstring_locales = locstring_locales_for_build(build, target_version);
+
     // Generate fields
     for field in &build.fields {
         let column = column_map.get(&field.name);
+
+        let is_locstring = column.is_some_and(|c| c.base_type == "locstring");
+
+        if is_locstring && !locstring_locales.is_empty() {
+            // Pre-4.1 layout: emit one StringRef per locale plus a flags field.
+            for locale in locstring_locales {
+                yaml.push_str(&format!("  - name: {}_{}\n", field.name, locale));
+                yaml.push_str("    type_name: String\n");
+                yaml.push_str(&format!(
+                    "    description: Localized {} text ({})\n",
+                    field.name.to_lowercase(),
+                    locale
+                ));
+            }
+            yaml.push_str(&format!("  - name: {}_flags\n", field.name));
+            yaml.push_str("    type_name: UInt32\n");
+            yaml.push_str(&format!(
+                "    description: Locale flags bitmask for {}\n",
+                field.name
+            ));
+            continue;
+        }
 
         // Determine field type
         let field_type = if let Some(col) = column {
@@ -639,6 +733,192 @@ mod tests {
         assert!(field.is_array);
         assert_eq!(field.array_size, Some(9));
         assert_eq!(field.type_size, TypeSize::UInt16);
+    }
+
+    #[test]
+    fn test_parse_skips_comment_lines() {
+        let dbd = "\
+COLUMNS
+int ID
+
+BUILD 3.3.5.12340
+COMMENT unknown_flag=1
+$id$ID<32>
+";
+        let dbd_file = parse_dbd_content(dbd).unwrap();
+        // The COMMENT line must not be turned into a phantom field.
+        assert_eq!(dbd_file.builds[0].fields.len(), 1);
+        assert_eq!(dbd_file.builds[0].fields[0].name, "ID");
+    }
+
+    #[test]
+    fn test_parse_field_line_strips_inline_comment() {
+        // DanceMoves.dbd has lines like `Name_lang // pre-8622 ...` — the comment
+        // must be stripped from the field name so column lookups still work.
+        let field =
+            parse_field_line("Name_lang // pre-8622 this uses the old 9 locale locstring format");
+        assert_eq!(field.name, "Name_lang");
+
+        let field = parse_field_line("$id$ID<32> // primary key");
+        assert_eq!(field.name, "ID");
+        assert!(field.is_key);
+        assert_eq!(field.type_size, TypeSize::Int32);
+    }
+
+    #[test]
+    fn test_parse_stacked_builds_share_fields() {
+        // AreaTrigger.dbd-style: several consecutive BUILD lines share a single
+        // field block. All builds should be saved with the same fields.
+        let dbd = "\
+COLUMNS
+int ID
+
+BUILD 3.0.8.9328
+BUILD 3.0.1.8303-3.3.5.12340
+BUILD 2.0.0.5610-2.4.3.8606
+$id$ID<32>
+";
+        let dbd_file = parse_dbd_content(dbd).unwrap();
+        // One stacked BUILD group becomes one DbdBuild whose `versions` lists all entries.
+        assert_eq!(dbd_file.builds.len(), 1);
+        assert_eq!(
+            dbd_file.builds[0].versions,
+            vec!["3.0.8.9328", "3.0.1.8303-3.3.5.12340", "2.0.0.5610-2.4.3.8606",]
+        );
+        assert_eq!(dbd_file.builds[0].fields.len(), 1);
+    }
+
+    #[test]
+    fn test_locstring_expansion_wotlk() {
+        let dbd = "\
+COLUMNS
+int ID
+locstring Name_lang
+int Flags
+
+BUILD 3.3.5.12340
+$id$ID<32>
+Name_lang
+Flags<32>
+";
+        let dbd_file = parse_dbd_content(dbd).unwrap();
+        let column_map: HashMap<String, &DbdColumn> =
+            dbd_file.columns.iter().map(|c| (c.name.clone(), c)).collect();
+        let yaml = generate_yaml_schema(
+            &column_map,
+            &dbd_file.builds[0],
+            "Test",
+            "3.3.5a",
+            Some("3.3.5"),
+        );
+        let name_lines: Vec<&str> = yaml
+            .lines()
+            .filter(|l| l.trim_start().starts_with("- name:"))
+            .collect();
+        // ID + 16 locale stringrefs + Name_lang_flags + Flags = 19
+        assert_eq!(name_lines.len(), 19);
+        assert!(yaml.contains("- name: Name_lang_enUS"));
+        assert!(yaml.contains("- name: Name_lang_ruRU"));
+        assert!(yaml.contains("- name: Name_lang_unk15"));
+        assert!(yaml.contains("- name: Name_lang_flags"));
+        assert!(!yaml.contains("- name: Name_lang\n"));
+    }
+
+    #[test]
+    fn test_locstring_expansion_classic() {
+        let dbd = "\
+COLUMNS
+int ID
+locstring Name_lang
+
+BUILD 1.12.1.5875
+$id$ID<32>
+Name_lang
+";
+        let dbd_file = parse_dbd_content(dbd).unwrap();
+        let column_map: HashMap<String, &DbdColumn> =
+            dbd_file.columns.iter().map(|c| (c.name.clone(), c)).collect();
+        let yaml = generate_yaml_schema(
+            &column_map,
+            &dbd_file.builds[0],
+            "Test",
+            "1.12.x",
+            Some("1.12"),
+        );
+        let name_lines: Vec<&str> = yaml
+            .lines()
+            .filter(|l| l.trim_start().starts_with("- name:"))
+            .collect();
+        // ID + 8 locale stringrefs + flags = 10
+        assert_eq!(name_lines.len(), 10);
+        assert!(yaml.contains("- name: Name_lang_enUS"));
+        assert!(!yaml.contains("- name: Name_lang_ruRU"));
+        assert!(yaml.contains("- name: Name_lang_flags"));
+    }
+
+    #[test]
+    fn test_locstring_no_expansion_modern() {
+        let dbd = "\
+COLUMNS
+int ID
+locstring Name_lang
+
+BUILD 5.4.8.18414
+$id$ID<32>
+Name_lang
+";
+        let dbd_file = parse_dbd_content(dbd).unwrap();
+        let column_map: HashMap<String, &DbdColumn> =
+            dbd_file.columns.iter().map(|c| (c.name.clone(), c)).collect();
+        let yaml = generate_yaml_schema(
+            &column_map,
+            &dbd_file.builds[0],
+            "Test",
+            "5.4.8",
+            Some("5.4.8"),
+        );
+        // ID + Name_lang (single string)
+        assert!(yaml.contains("- name: Name_lang\n"));
+        assert!(!yaml.contains("Name_lang_enUS"));
+    }
+
+    #[test]
+    fn test_locstring_expansion_uses_target_version_not_first_build() {
+        // Achievement_Category-style: a stacked BUILD group spans 6.0 down to
+        // 3.3.5; the listed *first* version is 6.0, but a 3.3.5 client needs
+        // the WotLK 16-locale layout. The target_version filter must win.
+        let dbd = "\
+COLUMNS
+int ID
+locstring Name_lang
+int Ui_order
+
+BUILD 6.0.1.18179
+BUILD 4.0.0.11792
+BUILD 3.0.1.8622-3.3.5.12340
+$id$ID<32>
+Name_lang
+Ui_order<32>
+";
+        let dbd_file = parse_dbd_content(dbd).unwrap();
+        let column_map: HashMap<String, &DbdColumn> =
+            dbd_file.columns.iter().map(|c| (c.name.clone(), c)).collect();
+        // Filtering for 3.3.5 should expand the locstring to 16 locales + flags.
+        let yaml = generate_yaml_schema(
+            &column_map,
+            &dbd_file.builds[0],
+            "Test",
+            "3.3.5a",
+            Some("3.3.5"),
+        );
+        let name_lines: Vec<&str> = yaml
+            .lines()
+            .filter(|l| l.trim_start().starts_with("- name:"))
+            .collect();
+        // ID + 16 locale stringrefs + Name_lang_flags + Ui_order = 19
+        assert_eq!(name_lines.len(), 19);
+        assert!(yaml.contains("- name: Name_lang_enUS"));
+        assert!(yaml.contains("- name: Name_lang_flags"));
     }
 
     #[test]

--- a/file-formats/database/wow-cdbc/src/dbd.rs
+++ b/file-formats/database/wow-cdbc/src/dbd.rs
@@ -783,7 +783,11 @@ $id$ID<32>
         assert_eq!(dbd_file.builds.len(), 1);
         assert_eq!(
             dbd_file.builds[0].versions,
-            vec!["3.0.8.9328", "3.0.1.8303-3.3.5.12340", "2.0.0.5610-2.4.3.8606",]
+            vec![
+                "3.0.8.9328",
+                "3.0.1.8303-3.3.5.12340",
+                "2.0.0.5610-2.4.3.8606",
+            ]
         );
         assert_eq!(dbd_file.builds[0].fields.len(), 1);
     }
@@ -802,8 +806,11 @@ Name_lang
 Flags<32>
 ";
         let dbd_file = parse_dbd_content(dbd).unwrap();
-        let column_map: HashMap<String, &DbdColumn> =
-            dbd_file.columns.iter().map(|c| (c.name.clone(), c)).collect();
+        let column_map: HashMap<String, &DbdColumn> = dbd_file
+            .columns
+            .iter()
+            .map(|c| (c.name.clone(), c))
+            .collect();
         let yaml = generate_yaml_schema(
             &column_map,
             &dbd_file.builds[0],
@@ -836,8 +843,11 @@ $id$ID<32>
 Name_lang
 ";
         let dbd_file = parse_dbd_content(dbd).unwrap();
-        let column_map: HashMap<String, &DbdColumn> =
-            dbd_file.columns.iter().map(|c| (c.name.clone(), c)).collect();
+        let column_map: HashMap<String, &DbdColumn> = dbd_file
+            .columns
+            .iter()
+            .map(|c| (c.name.clone(), c))
+            .collect();
         let yaml = generate_yaml_schema(
             &column_map,
             &dbd_file.builds[0],
@@ -868,8 +878,11 @@ $id$ID<32>
 Name_lang
 ";
         let dbd_file = parse_dbd_content(dbd).unwrap();
-        let column_map: HashMap<String, &DbdColumn> =
-            dbd_file.columns.iter().map(|c| (c.name.clone(), c)).collect();
+        let column_map: HashMap<String, &DbdColumn> = dbd_file
+            .columns
+            .iter()
+            .map(|c| (c.name.clone(), c))
+            .collect();
         let yaml = generate_yaml_schema(
             &column_map,
             &dbd_file.builds[0],
@@ -901,8 +914,11 @@ Name_lang
 Ui_order<32>
 ";
         let dbd_file = parse_dbd_content(dbd).unwrap();
-        let column_map: HashMap<String, &DbdColumn> =
-            dbd_file.columns.iter().map(|c| (c.name.clone(), c)).collect();
+        let column_map: HashMap<String, &DbdColumn> = dbd_file
+            .columns
+            .iter()
+            .map(|c| (c.name.clone(), c))
+            .collect();
         // Filtering for 3.3.5 should expand the locstring to 16 locales + flags.
         let yaml = generate_yaml_schema(
             &column_map,

--- a/file-formats/database/wow-cdbc/src/export.rs
+++ b/file-formats/database/wow-cdbc/src/export.rs
@@ -1,10 +1,14 @@
-//! Export functionality for DBC data
+//! Export and import functionality for DBC data
 
 use crate::{Record, RecordSet, Value};
+#[cfg(feature = "serde")]
+use crate::{Schema, StringBlock, StringRef};
 #[cfg(feature = "serde")]
 use serde::Serialize;
 use std::collections::HashMap;
 use std::io;
+#[cfg(feature = "serde")]
+use std::sync::Arc;
 
 /// A serializable wrapper for a record value
 #[cfg_attr(feature = "serde", derive(Serialize))]
@@ -107,6 +111,189 @@ pub fn export_to_json<W: io::Write>(record_set: &RecordSet, writer: W) -> Result
         .map_err(|e| io::Error::other(e.to_string()))
 }
 
+/// Import a record set from JSON, using a schema to determine field types.
+///
+/// The JSON must be an array of objects where each key matches a field name
+/// in the provided schema. String fields are expected as JSON strings; numeric
+/// and boolean fields are expected as their corresponding JSON primitives.
+///
+/// Returns a `RecordSet` ready to be written with `DbcWriter`.
+#[cfg(feature = "serde")]
+pub fn import_from_json<R: io::Read>(
+    reader: R,
+    schema: Schema,
+) -> Result<RecordSet, io::Error> {
+
+    let rows: Vec<serde_json::Map<String, serde_json::Value>> =
+        serde_json::from_reader(reader).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+    // Build a string block incrementally.
+    // Offset 0 is always the empty string (null terminator only).
+    let mut string_data: Vec<u8> = vec![0u8];
+    // Map from string content to its offset in the string block.
+    let mut string_offsets: HashMap<String, u32> = HashMap::new();
+    string_offsets.insert(String::new(), 0);
+
+    let schema_arc = Arc::new(schema.clone());
+    let mut records: Vec<Record> = Vec::with_capacity(rows.len());
+
+    for (row_idx, row) in rows.iter().enumerate() {
+        let mut values: Vec<Value> = Vec::with_capacity(schema.fields.len());
+
+        for field in &schema.fields {
+            let json_val = row.get(&field.name).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "row {}: missing field '{}' required by schema",
+                        row_idx, field.name
+                    ),
+                )
+            })?;
+
+            let value = if field.is_array {
+                let arr = json_val.as_array().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("row {}: field '{}' expected a JSON array", row_idx, field.name),
+                    )
+                })?;
+
+                let expected = field.array_size.unwrap_or(0);
+                if arr.len() != expected {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "row {}: field '{}' array has {} elements, expected {}",
+                            row_idx, field.name, arr.len(), expected
+                        ),
+                    ));
+                }
+
+                let mut elements = Vec::with_capacity(arr.len());
+                for (elem_idx, elem) in arr.iter().enumerate() {
+                    elements.push(parse_scalar(
+                        elem,
+                        field.field_type,
+                        &mut string_data,
+                        &mut string_offsets,
+                        row_idx,
+                        &format!("{}[{}]", field.name, elem_idx),
+                    )?);
+                }
+                Value::Array(elements)
+            } else {
+                parse_scalar(
+                    json_val,
+                    field.field_type,
+                    &mut string_data,
+                    &mut string_offsets,
+                    row_idx,
+                    &field.name,
+                )?
+            };
+
+            values.push(value);
+        }
+
+        records.push(Record::new(values, Some(Arc::clone(&schema_arc))));
+    }
+
+    let string_block = StringBlock::from_bytes(string_data);
+    Ok(RecordSet::new(records, Some(schema_arc), string_block))
+}
+
+/// Parse a single scalar JSON value into a DBC `Value` given a field type.
+#[cfg(feature = "serde")]
+fn parse_scalar(
+    json_val: &serde_json::Value,
+    field_type: crate::FieldType,
+    string_data: &mut Vec<u8>,
+    string_offsets: &mut HashMap<String, u32>,
+    row_idx: usize,
+    field_name: &str,
+) -> Result<Value, io::Error> {
+    use crate::FieldType;
+
+    let type_err = |expected: &str| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "row {}: field '{}' expected {}, got {}",
+                row_idx, field_name, expected, json_val
+            ),
+        )
+    };
+
+    Ok(match field_type {
+        FieldType::Int32 => {
+            let v = json_val.as_i64().ok_or_else(|| type_err("integer"))?;
+            Value::Int32(v as i32)
+        }
+        FieldType::UInt32 => {
+            let v = json_val.as_u64().ok_or_else(|| type_err("unsigned integer"))?;
+            Value::UInt32(v as u32)
+        }
+        FieldType::Float32 => {
+            let v = json_val.as_f64().ok_or_else(|| type_err("float"))?;
+            #[allow(clippy::cast_possible_truncation)]
+            Value::Float32(v as f32)
+        }
+        FieldType::Bool => {
+            // Accept JSON boolean or 0/1 integers
+            let v = if let Some(b) = json_val.as_bool() {
+                b
+            } else if let Some(n) = json_val.as_u64() {
+                n != 0
+            } else {
+                return Err(type_err("boolean"));
+            };
+            Value::Bool(v)
+        }
+        FieldType::UInt8 => {
+            let v = json_val.as_u64().ok_or_else(|| type_err("unsigned integer"))?;
+            Value::UInt8(v as u8)
+        }
+        FieldType::Int8 => {
+            let v = json_val.as_i64().ok_or_else(|| type_err("integer"))?;
+            Value::Int8(v as i8)
+        }
+        FieldType::UInt16 => {
+            let v = json_val.as_u64().ok_or_else(|| type_err("unsigned integer"))?;
+            Value::UInt16(v as u16)
+        }
+        FieldType::Int16 => {
+            let v = json_val.as_i64().ok_or_else(|| type_err("integer"))?;
+            Value::Int16(v as i16)
+        }
+        FieldType::String => {
+            let s = json_val.as_str().ok_or_else(|| type_err("string"))?;
+            let offset = intern_string(s, string_data, string_offsets);
+            Value::StringRef(StringRef::new(offset))
+        }
+    })
+}
+
+/// Intern a string into the string block, returning its offset.
+///
+/// If the string already exists in the block the existing offset is returned,
+/// avoiding duplicates.
+#[cfg(feature = "serde")]
+fn intern_string(
+    s: &str,
+    string_data: &mut Vec<u8>,
+    string_offsets: &mut HashMap<String, u32>,
+) -> u32 {
+    if let Some(&existing) = string_offsets.get(s) {
+        return existing;
+    }
+    let offset = string_data.len() as u32;
+    string_data.extend_from_slice(s.as_bytes());
+    string_data.push(0); // null terminator
+    string_offsets.insert(s.to_string(), offset);
+    offset
+}
+
 /// Export a record set to CSV
 #[cfg(feature = "csv_export")]
 pub fn export_to_csv<W: io::Write>(record_set: &RecordSet, writer: W) -> Result<(), io::Error> {
@@ -192,4 +379,110 @@ pub fn export_to_csv<W: io::Write>(record_set: &RecordSet, writer: W) -> Result<
 
     csv_writer.flush()?;
     Ok(())
+}
+
+#[cfg(test)]
+#[cfg(feature = "serde")]
+mod tests {
+    use super::*;
+    use crate::{DbcParser, DbcWriter, FieldType, Schema, SchemaField};
+    use std::io::Cursor;
+
+    fn make_test_schema() -> Schema {
+        let mut schema = Schema::new("Test");
+        schema.add_field(SchemaField::new("ID", FieldType::UInt32));
+        schema.add_field(SchemaField::new("Name", FieldType::String));
+        schema.add_field(SchemaField::new("Value", FieldType::UInt32));
+        schema.set_key_field("ID");
+        schema
+    }
+
+    fn make_test_dbc() -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"WDBC");
+        data.extend_from_slice(&2u32.to_le_bytes()); // record_count
+        data.extend_from_slice(&3u32.to_le_bytes()); // field_count
+        data.extend_from_slice(&12u32.to_le_bytes()); // record_size
+        data.extend_from_slice(&19u32.to_le_bytes()); // string_block_size
+        // Record 1
+        data.extend_from_slice(&1u32.to_le_bytes());
+        data.extend_from_slice(&1u32.to_le_bytes()); // "First" at offset 1
+        data.extend_from_slice(&100u32.to_le_bytes());
+        // Record 2
+        data.extend_from_slice(&2u32.to_le_bytes());
+        data.extend_from_slice(&7u32.to_le_bytes()); // "Second" at offset 7
+        data.extend_from_slice(&200u32.to_le_bytes());
+        // String block: \0First\0Second\0Extra\0
+        data.extend_from_slice(b"\x00First\x00Second\x00Extra\x00");
+        data
+    }
+
+    #[test]
+    fn test_json_roundtrip() {
+        // Parse original DBC
+        let dbc_bytes = make_test_dbc();
+        let parser = DbcParser::parse_bytes(&dbc_bytes).unwrap();
+        let parser = parser.with_schema(make_test_schema()).unwrap();
+        let original = parser.parse_records().unwrap();
+
+        // Export to JSON
+        let mut json_buf = Vec::new();
+        export_to_json(&original, &mut json_buf).unwrap();
+
+        // Import from JSON
+        let imported = import_from_json(Cursor::new(&json_buf), make_test_schema()).unwrap();
+
+        assert_eq!(imported.len(), 2);
+
+        let r0 = imported.get_record(0).unwrap();
+        assert!(matches!(r0.get_value(0), Some(Value::UInt32(1))));
+        assert!(matches!(r0.get_value(2), Some(Value::UInt32(100))));
+
+        if let Some(Value::StringRef(sr)) = r0.get_value(1) {
+            assert_eq!(imported.get_string(*sr).unwrap(), "First");
+        } else {
+            panic!("expected StringRef for Name field");
+        }
+
+        let r1 = imported.get_record(1).unwrap();
+        assert!(matches!(r1.get_value(0), Some(Value::UInt32(2))));
+        assert!(matches!(r1.get_value(2), Some(Value::UInt32(200))));
+
+        if let Some(Value::StringRef(sr)) = r1.get_value(1) {
+            assert_eq!(imported.get_string(*sr).unwrap(), "Second");
+        } else {
+            panic!("expected StringRef for Name field");
+        }
+
+        // Write the imported record set back to a DBC and re-parse it
+        let mut out_buf: Vec<u8> = Vec::new();
+        let mut writer = DbcWriter::new(Cursor::new(&mut out_buf));
+        writer.write_records(&imported).unwrap();
+
+        let parser2 = DbcParser::parse_bytes(&out_buf).unwrap();
+        let parser2 = parser2.with_schema(make_test_schema()).unwrap();
+        let final_set = parser2.parse_records().unwrap();
+
+        assert_eq!(final_set.len(), 2);
+
+        if let Some(Value::StringRef(sr)) = final_set.get_record(0).unwrap().get_value(1) {
+            assert_eq!(final_set.get_string(*sr).unwrap(), "First");
+        } else {
+            panic!("expected StringRef after write-read cycle");
+        }
+    }
+
+    #[test]
+    fn test_import_missing_field_error() {
+        let json = r#"[{"ID": 1, "Value": 100}]"#; // missing "Name"
+        let result = import_from_json(Cursor::new(json.as_bytes()), make_test_schema());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_import_type_mismatch_error() {
+        let json = r#"[{"ID": "not_a_number", "Name": "hi", "Value": 1}]"#;
+        let result = import_from_json(Cursor::new(json.as_bytes()), make_test_schema());
+        assert!(result.is_err());
+    }
 }

--- a/file-formats/database/wow-cdbc/src/export.rs
+++ b/file-formats/database/wow-cdbc/src/export.rs
@@ -119,13 +119,9 @@ pub fn export_to_json<W: io::Write>(record_set: &RecordSet, writer: W) -> Result
 ///
 /// Returns a `RecordSet` ready to be written with `DbcWriter`.
 #[cfg(feature = "serde")]
-pub fn import_from_json<R: io::Read>(
-    reader: R,
-    schema: Schema,
-) -> Result<RecordSet, io::Error> {
-
-    let rows: Vec<serde_json::Map<String, serde_json::Value>> =
-        serde_json::from_reader(reader).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+pub fn import_from_json<R: io::Read>(reader: R, schema: Schema) -> Result<RecordSet, io::Error> {
+    let rows: Vec<serde_json::Map<String, serde_json::Value>> = serde_json::from_reader(reader)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
     // Build a string block incrementally.
     // Offset 0 is always the empty string (null terminator only).
@@ -155,7 +151,10 @@ pub fn import_from_json<R: io::Read>(
                 let arr = json_val.as_array().ok_or_else(|| {
                     io::Error::new(
                         io::ErrorKind::InvalidData,
-                        format!("row {}: field '{}' expected a JSON array", row_idx, field.name),
+                        format!(
+                            "row {}: field '{}' expected a JSON array",
+                            row_idx, field.name
+                        ),
                     )
                 })?;
 
@@ -165,7 +164,10 @@ pub fn import_from_json<R: io::Read>(
                         io::ErrorKind::InvalidData,
                         format!(
                             "row {}: field '{}' array has {} elements, expected {}",
-                            row_idx, field.name, arr.len(), expected
+                            row_idx,
+                            field.name,
+                            arr.len(),
+                            expected
                         ),
                     ));
                 }
@@ -231,7 +233,9 @@ fn parse_scalar(
             Value::Int32(v as i32)
         }
         FieldType::UInt32 => {
-            let v = json_val.as_u64().ok_or_else(|| type_err("unsigned integer"))?;
+            let v = json_val
+                .as_u64()
+                .ok_or_else(|| type_err("unsigned integer"))?;
             Value::UInt32(v as u32)
         }
         FieldType::Float32 => {
@@ -251,7 +255,9 @@ fn parse_scalar(
             Value::Bool(v)
         }
         FieldType::UInt8 => {
-            let v = json_val.as_u64().ok_or_else(|| type_err("unsigned integer"))?;
+            let v = json_val
+                .as_u64()
+                .ok_or_else(|| type_err("unsigned integer"))?;
             Value::UInt8(v as u8)
         }
         FieldType::Int8 => {
@@ -259,7 +265,9 @@ fn parse_scalar(
             Value::Int8(v as i8)
         }
         FieldType::UInt16 => {
-            let v = json_val.as_u64().ok_or_else(|| type_err("unsigned integer"))?;
+            let v = json_val
+                .as_u64()
+                .ok_or_else(|| type_err("unsigned integer"))?;
             Value::UInt16(v as u16)
         }
         FieldType::Int16 => {

--- a/file-formats/database/wow-cdbc/src/lib.rs
+++ b/file-formats/database/wow-cdbc/src/lib.rs
@@ -107,7 +107,7 @@ pub use types::*;
 pub use schema_loader::{SchemaDefinition, SchemaFieldDefinition};
 
 #[cfg(feature = "serde")]
-pub use export::export_to_json;
+pub use export::{export_to_json, import_from_json};
 
 #[cfg(feature = "csv_export")]
 pub use export::export_to_csv;

--- a/file-formats/database/wow-cdbc/src/schema_loader.rs
+++ b/file-formats/database/wow-cdbc/src/schema_loader.rs
@@ -86,7 +86,9 @@ impl SchemaDefinition {
         }
 
         if let Some(key_field) = &self.key_field {
-            schema.set_key_field(key_field);
+            schema
+                .try_set_key_field(key_field)
+                .map_err(|e| format!("key_field '{}': {}", key_field, e))?;
         }
 
         Ok(schema)

--- a/file-formats/database/wow-cdbc/src/stringblock.rs
+++ b/file-formats/database/wow-cdbc/src/stringblock.rs
@@ -50,6 +50,14 @@ impl StringBlock {
         &self.data
     }
 
+    /// Create a string block from raw bytes.
+    ///
+    /// Used when constructing a `RecordSet` during import, where the string block
+    /// is built in memory rather than read from a file.
+    pub fn from_bytes(data: Vec<u8>) -> Self {
+        Self { data }
+    }
+
     /// Get the size of the string block in bytes
     pub fn size(&self) -> usize {
         self.data.len()

--- a/file-formats/graphics/wow-wmo/src/converter.rs
+++ b/file-formats/graphics/wow-wmo/src/converter.rs
@@ -121,17 +121,17 @@ impl WmoConverter {
         self.convert_group_flags(&mut group.header.flags, current_version, target_version);
 
         // Handle liquid data changes if needed
-        if group.liquid.is_some() {
+        if let Some(ref mut liquid) = group.liquid {
             if target_version >= WmoVersion::Wod
                 && !current_version.supports_feature(WmoFeature::LiquidV2)
             {
                 // Upgrade to LiquidV2 format (more complex liquid data)
-                self.upgrade_liquid_to_v2(group.liquid.as_mut().unwrap())?;
+                self.upgrade_liquid_to_v2(liquid)?;
             } else if target_version < WmoVersion::Wod
                 && current_version.supports_feature(WmoFeature::LiquidV2)
             {
                 // Downgrade from LiquidV2 format (simplify liquid data)
-                self.downgrade_liquid_from_v2(group.liquid.as_mut().unwrap())?;
+                self.downgrade_liquid_from_v2(liquid)?;
             }
         }
 

--- a/file-formats/world-data/wow-adt/src/builder/validation.rs
+++ b/file-formats/world-data/wow-adt/src/builder/validation.rs
@@ -4,12 +4,12 @@
 //! - Method-level: Basic parameter checks
 //! - Build-level: Structural and reference validation
 
-use crate::ChunkId;
+use crate::chunks::blend_mesh::{MbbbChunk, MbmhChunk, MbmiChunk, MbnvChunk};
 use crate::chunks::DoodadPlacement;
 use crate::chunks::WmoPlacement;
-use crate::chunks::blend_mesh::{MbbbChunk, MbmhChunk, MbmiChunk, MbnvChunk};
 use crate::error::{AdtError, Result};
 use crate::version::AdtVersion;
+use crate::ChunkId;
 
 /// Validate texture filename format.
 ///
@@ -188,22 +188,22 @@ pub fn validate_version_chunk_compatibility(version: AdtVersion, chunk: ChunkId)
                 });
             }
         }
-        ChunkId::MTXP | ChunkId::MBMH | ChunkId::MBBB | ChunkId::MBNV | ChunkId::MBMI => {
-            if version != AdtVersion::MoP {
-                let chunk_name = match chunk {
-                    ChunkId::MTXP => "MTXP (texture parameters)",
-                    ChunkId::MBMH => "MBMH (blend mesh headers)",
-                    ChunkId::MBBB => "MBBB (blend mesh bounds)",
-                    ChunkId::MBNV => "MBNV (blend mesh vertices)",
-                    ChunkId::MBMI => "MBMI (blend mesh indices)",
-                    _ => unreachable!(),
-                };
-                return Err(AdtError::ChunkParseError {
-                    chunk,
-                    offset: 0,
-                    details: format!("{} requires MoP, but version is {:?}", chunk_name, version),
-                });
-            }
+        ChunkId::MTXP | ChunkId::MBMH | ChunkId::MBBB | ChunkId::MBNV | ChunkId::MBMI
+            if version != AdtVersion::MoP =>
+        {
+            let chunk_name = match chunk {
+                ChunkId::MTXP => "MTXP (texture parameters)",
+                ChunkId::MBMH => "MBMH (blend mesh headers)",
+                ChunkId::MBBB => "MBBB (blend mesh bounds)",
+                ChunkId::MBNV => "MBNV (blend mesh vertices)",
+                ChunkId::MBMI => "MBMI (blend mesh indices)",
+                _ => unreachable!(),
+            };
+            return Err(AdtError::ChunkParseError {
+                chunk,
+                offset: 0,
+                details: format!("{} requires MoP, but version is {:?}", chunk_name, version),
+            });
         }
         _ => {}
     }

--- a/warcraft-rs/Cargo.toml
+++ b/warcraft-rs/Cargo.toml
@@ -63,6 +63,16 @@ serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 serde_yaml_ng = { version = "0.10", optional = true }
 
+# Transitive dependency version floors (not used directly here; pinned to
+# raise the resolver's minimum across the workspace).
+# aegis: pulled in via turso. 0.9.7 fails to build on clang >= 22 because its
+#   per-function `target("...,evex512")` attribute no longer enables avx512f.
+#   0.9.8 gates the evex512 form to clang 18-21.
+# num-bigint-dig: pulled in via rsa (wow-mpq). 0.8.4 uses the private `vec!`
+#   macro re-export which is a future-incompat in rustc. Fixed in 0.8.5+.
+aegis = { version = "0.9.8", optional = true }
+num-bigint-dig = { version = "0.8.6", default-features = false, features = ["i128", "prime", "zeroize"] }
+
 [features]
 default = ["mpq", "dbc", "blp", "m2", "wmo", "adt", "wdt", "wdl"]
 full = [
@@ -79,7 +89,7 @@ full = [
   "parallel",
   "yaml",
 ]
-mpq = ["dep:turso", "dep:directories"]
+mpq = ["dep:turso", "dep:directories", "dep:aegis"]
 dbc = ["dep:wow-cdbc"]
 blp = ["dep:wow-blp", "dep:image"]
 m2 = ["dep:wow-m2"]

--- a/warcraft-rs/src/commands/blp.rs
+++ b/warcraft-rs/src/commands/blp.rs
@@ -690,12 +690,11 @@ fn validate_blp(file: PathBuf, strict: bool) -> Result<()> {
                 errors.push("JPEG header is empty".to_string());
             }
         }
-        BlpContent::Dxt1(_) | BlpContent::Dxt3(_) | BlpContent::Dxt5(_) => {
+        BlpContent::Dxt1(_) | BlpContent::Dxt3(_) | BlpContent::Dxt5(_)
             // DXT requires dimensions to be multiples of 4
-            if blp.header.width % 4 != 0 || blp.header.height % 4 != 0 {
+            if (blp.header.width % 4 != 0 || blp.header.height % 4 != 0) => {
                 errors.push("DXT format requires dimensions to be multiples of 4".to_string());
             }
-        }
         _ => {}
     }
 

--- a/warcraft-rs/src/commands/dbc.rs
+++ b/warcraft-rs/src/commands/dbc.rs
@@ -7,7 +7,8 @@ use std::io::{self, BufReader, BufWriter};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 use wow_cdbc::{
-    DbcParser, RecordSet, SchemaDefinition, SchemaDiscoverer, Value, export_to_csv, export_to_json,
+    DbcParser, DbcWriter, RecordSet, SchemaDefinition, SchemaDiscoverer, Value, export_to_csv,
+    export_to_json, import_from_json,
 };
 
 #[cfg(feature = "yaml")]
@@ -61,6 +62,20 @@ pub enum DbcCommands {
         /// Output file (stdout if not specified)
         #[arg(short, long)]
         output: Option<PathBuf>,
+    },
+
+    /// Import DBC data from a JSON file
+    Import {
+        /// Path to the input JSON file
+        file: PathBuf,
+
+        /// Path to the schema YAML file
+        #[arg(short, long)]
+        schema: PathBuf,
+
+        /// Output DBC file path
+        #[arg(short, long)]
+        output: PathBuf,
     },
 
     /// Analyze a DBC file for performance and structure
@@ -140,6 +155,11 @@ pub fn execute(command: DbcCommands) -> Result<()> {
             format,
             output,
         } => export_command(&file, &schema, format, output.as_deref()),
+        DbcCommands::Import {
+            file,
+            schema,
+            output,
+        } => import_command(&file, &schema, &output),
         DbcCommands::Analyze {
             file,
             schema,
@@ -380,6 +400,46 @@ fn export_command(
             }
         }
     }
+
+    Ok(())
+}
+
+/// Import DBC data from a JSON file using a schema
+fn import_command(file: &Path, schema_path: &Path, output: &Path) -> Result<()> {
+    // Load schema
+    let schema_def = SchemaDefinition::from_yaml(schema_path)
+        .map_err(|e| anyhow::anyhow!("Failed to load schema {}: {}", schema_path.display(), e))?;
+    let schema = schema_def
+        .to_schema()
+        .map_err(|e| anyhow::anyhow!("Failed to convert schema definition: {}", e))?;
+
+    // Open JSON input
+    let json_file = File::open(file)
+        .with_context(|| format!("Failed to open JSON file: {}", file.display()))?;
+    let reader = BufReader::new(json_file);
+
+    // Parse JSON into a record set
+    let record_set = import_from_json(reader, schema)
+        .with_context(|| format!("Failed to import JSON file: {}", file.display()))?;
+
+    let record_count = record_set.len();
+
+    // Write output DBC file
+    let output_file = File::create(output)
+        .with_context(|| format!("Failed to create output file: {}", output.display()))?;
+    let writer = BufWriter::new(output_file);
+
+    let mut dbc_writer = DbcWriter::new(writer);
+    dbc_writer
+        .write_records(&record_set)
+        .with_context(|| format!("Failed to write DBC file: {}", output.display()))?;
+
+    println!(
+        "Imported {} records from {} to {}",
+        record_count,
+        file.display(),
+        output.display()
+    );
 
     Ok(())
 }

--- a/warcraft-rs/src/commands/mpq.rs
+++ b/warcraft-rs/src/commands/mpq.rs
@@ -1854,12 +1854,10 @@ fn create_file_node(
                     .with_external_ref(&format!("{base_name}.skin"), detect_ref_type("file.skin"));
                 node = node.with_external_ref("*.blp", detect_ref_type("file.blp"));
             }
-            "dbc" => {
-                // Some DBC files reference other files
-                if file_name.to_lowercase().contains("item") {
-                    node = node
-                        .with_external_ref("Interface/Icons/*.blp", detect_ref_type("file.blp"));
-                }
+            "dbc"
+                if file_name.to_lowercase().contains("item") =>
+            {
+                node = node.with_external_ref("Interface/Icons/*.blp", detect_ref_type("file.blp"));
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary

- Add `dbc import` CLI subcommand: reads a JSON file + schema YAML and writes a valid WDBC-format DBC binary
- Add `import_from_json` to `wow-cdbc` library: builds a `RecordSet` from JSON with type coercion and string block deduplication
- Fix `dbd_to_yaml` binary to produce schemas compatible with the schema loader (`type_name` field, per-build layout, array sizes)
- Fix `generate_yaml_schema` in `dbd.rs` to omit `key_field` when no `$id$` marker exists in the build definition
- Fix `schema_loader::to_schema` to return an error instead of panicking on unknown key field names

## Usage

```
# 1. Convert a WoWDBDefs definition to a YAML schema
dbd_to_yaml Spell.dbd Spell.yaml

# 2. Export a DBC to JSON (existing command)
warcraft-rs dbc export --schema Spell.yaml --format json Spell.dbc --output Spell.json

# 3. Edit Spell.json as needed, then import back
warcraft-rs dbc import --schema Spell.yaml --output Spell_modified.dbc Spell.json
```

## Test plan

- [ ] `cargo test --workspace` passes (all tests green, zero failures)
- [ ] `cargo clippy --workspace --all-features` passes (no warnings)
- [ ] Three new unit tests in `export.rs`: JSON round-trip, missing field error, type mismatch error
- [ ] Manual smoke test with real 3.3.5a `AttackAnimTypes.dbc`: validate → export → modify → import → validate
