### PR TITLE
fix(wow-adt): fix last row/column in 4-bit alpha map decompression

### DIFF
--- a/file-formats/world-data/wow-adt/src/chunks/mcnk/mcal.rs
+++ b/file-formats/world-data/wow-adt/src/chunks/mcnk/mcal.rs
@@ -71,6 +71,22 @@ impl AlphaMap {
                     output.push(low | (low << 4));
                     output.push(high | (high << 4));
                 }
+
+                // Fix last column and last row: old 4-bit alpha maps store
+                // only 63 meaningful values per axis; the 64th column/row
+                // contains undefined data.  Copy the second-to-last value
+                // into the last position so that edge texels are
+                // well-defined and match neighbouring chunks.
+                // Reference: Noggit3 Alphamap::readNotCompressed().
+                for i in 0..Self::RESOLUTION {
+                    output[i * Self::RESOLUTION + (Self::RESOLUTION - 1)] =
+                        output[i * Self::RESOLUTION + (Self::RESOLUTION - 2)];
+                    output[(Self::RESOLUTION - 1) * Self::RESOLUTION + i] =
+                        output[(Self::RESOLUTION - 2) * Self::RESOLUTION + i];
+                }
+                output[(Self::RESOLUTION - 1) * Self::RESOLUTION + (Self::RESOLUTION - 1)] =
+                    output[(Self::RESOLUTION - 2) * Self::RESOLUTION + (Self::RESOLUTION - 2)];
+
                 Ok(output)
             }
 
@@ -488,6 +504,42 @@ mod tests {
         // Byte 2: 0x8A -> low=0xA (0xAA), high=0x8 (0x88)
         assert_eq!(decompressed[4], 0xAA);
         assert_eq!(decompressed[5], 0x88);
+    }
+
+    #[test]
+    fn uncompressed_2048_last_row_col_fix() {
+        // Old 4-bit alpha maps have undefined data in the last column (63)
+        // and last row (63).  decompress() should copy column 62 → 63 and
+        // row 62 → 63 to eliminate chunk-boundary seams.
+        let mut data = vec![0u8; 2048];
+
+        // Put a distinctive value at row 0, col 62 (byte index 31 in
+        // 4-bit packed form: col 62 is the high nibble of byte 31).
+        // 4-bit packed: byte i holds col 2i (low) and col 2i+1 (high).
+        // col 62 = high nibble of byte 31 → value 0xA
+        data[31] = 0xA0; // low nibble (col 62)=0, high nibble (col 63)=0xA
+        // Actually: byte 31 → col 62 = low nibble, col 63 = high nibble
+        // Let's set col 62 (low nibble of byte 31) to 0xB
+        data[31] = 0x0B; // col 62 = 0xB (expands to 0xBB), col 63 = 0x0
+
+        let alpha_map = AlphaMap::new(data, AlphaFormat::Uncompressed2048);
+        let decompressed = alpha_map.decompress().unwrap();
+
+        // After fix: col 63 should equal col 62 on row 0
+        let col62 = decompressed[0 * 64 + 62]; // 0xBB
+        let col63 = decompressed[0 * 64 + 63];
+        assert_eq!(col62, 0xBB);
+        assert_eq!(col63, col62, "last column should be copied from second-to-last");
+
+        // Row 63 should equal row 62 (both are all-zero in this test)
+        for col in 0..64 {
+            assert_eq!(
+                decompressed[63 * 64 + col],
+                decompressed[62 * 64 + col],
+                "last row at col {} should match second-to-last row",
+                col,
+            );
+        }
     }
 
     #[test]
@@ -1003,9 +1055,19 @@ mod tests {
         assert_eq!(alpha_map.format, AlphaFormat::Uncompressed2048);
         assert_eq!(alpha_map.data.len(), 2048);
 
-        // Verify round-trip
+        // Verify round-trip (last row/column is fixed by decompress, so
+        // compare only the interior 63×63 region).
         let decompressed = alpha_map.decompress().unwrap();
-        assert_eq!(decompressed, data);
+        for row in 0..63 {
+            for col in 0..63 {
+                assert_eq!(
+                    decompressed[row * 64 + col],
+                    data[row * 64 + col],
+                    "mismatch at ({}, {})",
+                    col, row,
+                );
+            }
+        }
     }
 
     #[test]
@@ -1093,9 +1155,19 @@ mod tests {
         assert_eq!(alpha_map.format, AlphaFormat::Uncompressed2048);
         assert_eq!(alpha_map.data.len(), 2048);
 
-        // Verify round-trip
+        // Verify round-trip (last row/column is fixed by decompress, so
+        // compare only the interior 63×63 region).
         let decompressed = alpha_map.decompress().unwrap();
-        assert_eq!(decompressed, data);
+        for row in 0..63 {
+            for col in 0..63 {
+                assert_eq!(
+                    decompressed[row * 64 + col],
+                    data[row * 64 + col],
+                    "mismatch at ({}, {})",
+                    col, row,
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
# Pull Request

## Summary

Old 4-bit (Uncompressed2048) alpha maps only have 63 meaningful values per axis; the 64th column and row contain undefined data. This causes visible seam lines at MCNK chunk boundaries when rendering terrain.

Copy the second-to-last column/row into the last position during decompression, matching the fix in Noggit3's Alphamap::readNotCompressed().

Reference: https://wowdev.wiki/ADT/v18#MCAL_sub-chunk

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Build system/dependency changes
- [ ] Security fix

## Changes Made

 - Added last row/column fixup in AlphaMap::decompress() for Uncompressed2048 format: copies column 62 → 63 and row 62 → 63 after 4-bit → 8-bit expansion, matching Noggit3's Alphamap::readNotCompressed()
  behavior
 - Added uncompressed_2048_last_row_col_fix test verifying the fixup correctly propagates second-to-last values to the last column and row
 - Updated optimal_format_chooses_4bit_for_nibble_safe_data and optimal_format_mixed_4bit_safe round-trip tests to compare only the interior 63×63 region, since the last row/column is now intentionally
 modified during decompression

## Related Issues

None

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## Testing
In a Rust wow map viewer that uses warcraft-rs crates, before fix:
<img width="639" height="382" alt="beforefix" src="https://github.com/user-attachments/assets/30a4f11c-9c20-45f7-baaf-f6a87519d9a9" />

After fix:
<img width="638" height="380" alt="afterfix" src="https://github.com/user-attachments/assets/939c58e1-df4f-4fb7-97f1-5f8874529a5d" />

### Test Cases Added/Modified

- [x] Unit tests
- [ ] Integration tests
- [ ] Compliance tests (StormLib compatibility)
- [ ] Performance benchmarks
- [ ] Manual testing

### Test Results

all pass

```bash
cargo test -p wow-adt -- chunks::mcnk::mcal::tests::uncompressed_2048_last_row_col_fix

 # Run all mcal tests (includes our updated round-trip tests)
 cargo test -p wow-adt -- chunks::mcnk::mcal

 # Run the full wow-adt test suite
 cargo test -p wow-adt
```

### Tested On

<!-- Check all that apply -->

- [ ] Linux
- [x] macOS - apple silicone
- [ ] Windows
- [ ] Cross-compilation targets

### WoW Versions Tested

- [x] 1.12.1 (Vanilla)
- [ ] 2.4.3 (TBC)
- [ ] 3.3.5a (WotLK)
- [ ] 4.3.4 (Cataclysm)
- [ ] 5.4.8 (MoP)
- [ ] Other: _______________

## Quality Assurance

<!-- Confirm you've completed these steps -->

### Code Quality

Happy to do more of these if this PR fits this project's scope.

- [ ] Code follows project style guidelines
- [ ] Self-review of code completed
- [ ] Code is properly documented
- [x] No obvious performance regressions
- [ ] Error handling is appropriate

### Required Checks

Happy to do more of these if this PR fits this project's scope.

- [ ] `cargo fmt --all` - Code is formatted
- [ ] `cargo clippy --all-targets --all-features` - No clippy warnings
- [ ] `cargo test --all-features` - All tests pass
- [ ] `cargo test --no-default-features` - Tests pass without features
- [ ] `cargo deny check` - No security/license issues
- [ ] Documentation builds successfully

### Compatibility

Happy to do more of these if this PR fits this project's scope.

- [ ] No breaking changes to public API (or properly documented)
- [ ] Backward compatibility maintained where possible
- [ ] StormLib compatibility preserved (if applicable)
- [ ] Cross-platform compatibility verified

## Documentation

Happy to do more of these if this PR fits this project's scope.

- [ ] Updated relevant documentation in `docs/`
- [ ] Updated CHANGELOG.md
- [ ] Updated README.md (if applicable)
- [ ] Added/updated code examples
- [ ] Added/updated CLI help text
- [ ] API documentation updated (rustdoc)

## Benchmarks

<!-- If applicable, include benchmark results -->

### Performance Impact

Happy to do more of these if this PR fits this project's scope.

- [ ] No performance impact
- [ ] Performance improvement (include metrics)
- [ ] Performance regression (justified and documented)

### Benchmark Results

Happy to do more of these if this PR fits this project's scope.

```
# Before:
test bench_parse_archive ... bench: 1,234 ns/iter (+/- 56)

# After:
test bench_parse_archive ... bench: 987 ns/iter (+/- 43)
```

## Breaking Changes

No

### API Changes

Happy to do more of these if this PR fits this project's scope.

### Migration Guide

N/A

## Security Considerations

<!-- If applicable, describe security implications -->

- [x] No security implications
- [ ] Security improvement
- [ ] Potential security impact (reviewed and justified)

## Additional Context

<!-- Add any other context about the PR -->

### Dependencies

<!-- List any new dependencies or dependency updates -->

### Known Limitations

<!-- Describe any known limitations or future work needed -->

### Screenshots/Examples

<!-- Include screenshots, command output, or examples if helpful -->

---

## Reviewer Notes

<!-- Notes for reviewers -->

### Areas of Focus

<!-- Highlight specific areas where you'd like reviewer attention -->

### Questions for Reviewers

<!-- Any specific questions you have for reviewers -->

---

**By submitting this PR, I confirm that:**

- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] This PR is ready for review (not a draft)
- [x] I am willing to address feedback and make necessary changes
- [x] I understand this may take time to review and merge