### PR TITLE
fix(wow-blp): palettized BLP palette is BGRX, not 0xBBGGRR — swap R↔B

### DIFF
--- a/file-formats/graphics/wow-blp/src/convert/palette.rs
+++ b/file-formats/graphics/wow-blp/src/convert/palette.rs
@@ -15,15 +15,15 @@ pub fn quantize_rgba(
     // quantize
     let nq = color_quant::NeuQuant::new(sample_fact, palette_size, img.as_raw());
     let quantized: Vec<u8> = img.pixels().map(|pix| nq.index_of(&pix.0) as u8).collect();
-    // collect palette
+    // collect palette — BLP palette entries are BGRX on disk (0x00RRGGBB as u32).
     let palette = nq
         .color_map_rgb()
         .chunks(3)
         .map(|col| {
-            let red = col[0] as u32;
+            let blue = col[2] as u32;
             let green = (col[1] as u32) << 8;
-            let blue = (col[2] as u32) << 16;
-            red + green + blue
+            let red = (col[0] as u32) << 16;
+            red | green | blue
         })
         .collect();
 

--- a/file-formats/graphics/wow-blp/src/convert/raw1.rs
+++ b/file-formats/graphics/wow-blp/src/convert/raw1.rs
@@ -31,9 +31,9 @@ pub fn raw1_to_image(
         for (i, pixel) in res_image.pixels_mut().enumerate() {
             let ci = raw_image.indexed_rgb[i];
             let color = image.cmap[ci as usize];
-            pixel.0[0] = (color & 0xFF) as u8;
-            pixel.0[1] = ((color >> 8) & 0xFF) as u8;
-            pixel.0[2] = ((color >> 16) & 0xFF) as u8;
+            pixel.0[0] = ((color >> 16) & 0xFF) as u8; // R
+            pixel.0[1] = ((color >> 8) & 0xFF) as u8;  // G
+            pixel.0[2] = (color & 0xFF) as u8;          // B
         }
         Ok(DynamicImage::ImageRgb8(res_image))
     } else if alpha_bits == 1 {
@@ -52,9 +52,9 @@ pub fn raw1_to_image(
         for (i, pixel) in res_image.pixels_mut().enumerate() {
             let ci = raw_image.indexed_rgb[i];
             let color = image.cmap[ci as usize];
-            pixel.0[0] = (color & 0xFF) as u8;
-            pixel.0[1] = ((color >> 8) & 0xFF) as u8;
-            pixel.0[2] = ((color >> 16) & 0xFF) as u8;
+            pixel.0[0] = ((color >> 16) & 0xFF) as u8; // R
+            pixel.0[1] = ((color >> 8) & 0xFF) as u8;  // G
+            pixel.0[2] = (color & 0xFF) as u8;          // B
             let bit = (raw_image.indexed_alpha[i / 8] >> (i % 8)) & 0x01;
             pixel.0[3] = if bit == 1 { 255 } else { 0 };
         }
@@ -76,9 +76,9 @@ pub fn raw1_to_image(
         for (i, pixel) in res_image.pixels_mut().enumerate() {
             let ci = raw_image.indexed_rgb[i];
             let color = image.cmap[ci as usize];
-            pixel.0[0] = (color & 0xFF) as u8;
-            pixel.0[1] = ((color >> 8) & 0xFF) as u8;
-            pixel.0[2] = ((color >> 16) & 0xFF) as u8;
+            pixel.0[0] = ((color >> 16) & 0xFF) as u8; // R
+            pixel.0[1] = ((color >> 8) & 0xFF) as u8;  // G
+            pixel.0[2] = (color & 0xFF) as u8;          // B
             let alpha_block = raw_image.indexed_alpha[i / 2];
             let nibble = if i % 2 == 0 {
                 alpha_block & 0x0F
@@ -104,9 +104,9 @@ pub fn raw1_to_image(
         for (i, pixel) in res_image.pixels_mut().enumerate() {
             let ci = raw_image.indexed_rgb[i];
             let color = image.cmap[ci as usize];
-            pixel.0[0] = (color & 0xFF) as u8;
-            pixel.0[1] = ((color >> 8) & 0xFF) as u8;
-            pixel.0[2] = ((color >> 16) & 0xFF) as u8;
+            pixel.0[0] = ((color >> 16) & 0xFF) as u8; // R
+            pixel.0[1] = ((color >> 8) & 0xFF) as u8;  // G
+            pixel.0[2] = (color & 0xFF) as u8;          // B
             pixel.0[3] = raw_image.indexed_alpha[i];
         }
         Ok(DynamicImage::ImageRgba8(res_image))

--- a/file-formats/graphics/wow-blp/src/types/direct/raw1.rs
+++ b/file-formats/graphics/wow-blp/src/types/direct/raw1.rs
@@ -7,10 +7,10 @@ use crate::types::{
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BlpRaw1 {
     /// The cmap field array is the colour look up table used for an indexed
-    /// colour model. Each element represents 24 bit RGB colour component values
-    /// in the order of 0xBBGGRR. The final byte is alignment padding and will
-    /// not alter the decoded image in any way. One might be able to improve the
-    /// file compressibility by carefully choosing padding values.
+    /// colour model. Each element is a 32-bit value stored as BGRX on disk
+    /// (byte 0 = B, byte 1 = G, byte 2 = R, byte 3 = padding). As a
+    /// little-endian u32 this is `0x00RRGGBB`. Alpha is stored in a separate
+    /// per-pixel array, not in the palette.
     pub cmap: Vec<u32>,
     /// Image itself and all mipmaps levels. If there are no mipmaps,
     /// the length of the vector is 1.

--- a/file-formats/graphics/wow-blp/src/types/direct/raw3.rs
+++ b/file-formats/graphics/wow-blp/src/types/direct/raw3.rs
@@ -7,10 +7,10 @@ use super::super::{
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BlpRaw3 {
     /// The cmap field array is the colour look up table used for an indexed
-    /// colour model. Each element represents 24 bit RGB colour component values
-    /// in the order of 0xBBGGRR. The final byte is alignment padding and will
-    /// not alter the decoded image in any way. One might be able to improve the
-    /// file compressibility by carefully choosing padding values.
+    /// colour model. Each element is a 32-bit value stored as BGRX on disk
+    /// (byte 0 = B, byte 1 = G, byte 2 = R, byte 3 = padding). As a
+    /// little-endian u32 this is `0x00RRGGBB`. Alpha is stored in a separate
+    /// per-pixel array, not in the palette.
     pub cmap: Vec<u32>,
     /// Image itself and all mipmaps levels. If there are no mipmaps,
     /// the length of the vector is 1.


### PR DESCRIPTION
## Problem

The BLP2 palette colour map is stored as **BGRX on disk** (byte 0 = B, byte 1 = G, byte 2 = R, byte 3 = padding). As a little-endian u32 this is `0x00RRGGBB`.

The encoder packed it as `0x00BBGGRR` (R in byte 0, B in byte 2) and the decoder extracted channels to match. Round-tripping wow-blp's own output worked, but reading real Blizzard BLPs swapped red and blue.

## Evidence

Verified against 3.3.5a client (build 12340) reverse engineering analysis:

> `DecompPalFastPath` copies 3 bytes from each palette entry as BGR, confirming the palette format is **BGRX** (blue, green, red, padding), not BGRA.

## Changes

- **Encoder** (`palette.rs`): Pack palette entries as `0x00RRGGBB` (B in byte 0, R in byte 2) matching the BGRX disk layout
- **Decoder** (`raw1.rs`): Extract R from bits 16–23 and B from bits 0–7 of each palette u32
- **Doc comments** (`BlpRaw1`, `BlpRaw3`): Corrected `0xBBGGRR` → `0x00RRGGBB` and clarified alpha is in a separate array

## Supersedes

- Closes #52 — same channel fix, no doc comment correction
- Closes #58 — same channel fix with BGRA comments (should be BGRX), also bundles unrelated M2 resilience changes (those are in #57)